### PR TITLE
Create new element with mass as float, not string

### DIFF
--- a/foyer/forcefield.py
+++ b/foyer/forcefield.py
@@ -167,7 +167,7 @@ class Forcefield(app.ForceField):
                         warnings.warn('Non-atomistic element type detected. '
                                       'Creating custom element for {}'.format(element))
                     element = elem.Element(number=0,
-                                           mass=parameters['mass'],
+                                           mass=mass,
                                            name=element,
                                            symbol=element)
                     self.non_element_types[element.name] = element


### PR DESCRIPTION
forcefield.registerAtomType() was creating a new element with the mass
that ParmEd was passing it, which is a string. The mass was converted to
a floating point number in the function, but that was not what was
passed to simtk.openmm.app.element.Element().  This was causing errors
in the hoomdxml writer when trying to divide by the reference mass
(since hoomd uses reduced units).