### PR TITLE
Order bonds in Structure by index of first atom

### DIFF
--- a/foyer/forcefield.py
+++ b/foyer/forcefield.py
@@ -222,6 +222,7 @@ class Forcefield(app.ForceField):
         box_vectors = topology.getPeriodicBoxVectors()
         system = self.createSystem(topology, *args, **kwargs)
         structure = pmd.openmm.load_topology(topology=topology, system=system)
+        structure.bonds.sort(key=lambda x: x.atom1.idx)
         structure.positions = positions
         if box_vectors is not None:
             structure.box_vectors = box_vectors


### PR DESCRIPTION
Angles and dihedrals were already ordered by the index of the first
atom, but bonds were not. This ordering is typically not important,
but can apparently cause some issues in some downstream software.

Should resolve mosdef-hub/mbuild#273