### PR TITLE
Fix when passing in a compound with a bounding box < 3 dimensions

### DIFF
--- a/foyer/forcefield.py
+++ b/foyer/forcefield.py
@@ -28,9 +28,11 @@ def generate_topology(non_omm_topology, non_element_types=None):
     if non_element_types is None:
         non_element_types = set()
 
-    if (isinstance(non_omm_topology, pmd.Structure) or
-            isinstance(non_omm_topology, mb.Compound)):
+    if isinstance(non_omm_topology, pmd.Structure):
         return _topology_from_parmed(non_omm_topology, non_element_types)
+    elif isinstance(non_omm_topology, mb.Compound):
+        pmdCompoundStructure = non_omm_topology.to_parmed()
+        return _topology_from_parmed(pmdCompoundStructure, non_element_types)
     else:
         raise FoyerError('Unknown topology format: {}\n'
                          'Supported formats are: '
@@ -41,12 +43,9 @@ def generate_topology(non_omm_topology, non_element_types=None):
 
 def _topology_from_parmed(structure, non_element_types):
     """Convert a ParmEd Structure to an OpenMM Topology. """
-    if isinstance(structure, mb.Compound):
-        structure = structure.to_parmed()
 
     topology = app.Topology()
     chain = topology.addChain()
-
     residue = topology.addResidue(structure.title, chain)
     atoms = dict()  # pmd.Atom: omm.Atom
 

--- a/foyer/tests/test_forcefield.py
+++ b/foyer/tests/test_forcefield.py
@@ -4,7 +4,6 @@ from pkg_resources import resource_filename
 
 import mbuild as mb
 import parmed as pmd
-import parmed.unit as u
 import pytest
 
 from foyer import Forcefield
@@ -67,11 +66,6 @@ def test_from_mbuild():
     assert all(x.type for x in ethane.angles)
     assert len(ethane.rb_torsions) == 9
     assert all(x.type for x in ethane.dihedrals)
-
-    boundingbox = mol2.boundingbox
-    assert ethane.box_vectors[0][0].value_in_unit(u.nanometers) == boundingbox.lengths[0]
-    assert ethane.box_vectors[1][1].value_in_unit(u.nanometers) == boundingbox.lengths[1]
-    assert ethane.box_vectors[2][2].value_in_unit(u.nanometers) == boundingbox.lengths[2]
 
 def test_write_refs():
     mol2 = mb.load(get_fn('ethane.mol2'))


### PR DESCRIPTION
1. Applicable to mBuild Compounds
	* converts to parmed structure first( which will either accept a custom box, or None)
	* if none, will pad all dimensions by 0.5nm.
	* alleviates the error when atom typing with a < 3dimensional box

Fixes #105 