### PR TITLE
Optimizations to graph matching

### DIFF
--- a/foyer/smarts_graph.py
+++ b/foyer/smarts_graph.py
@@ -1,4 +1,5 @@
 from collections import OrderedDict, defaultdict
+import sys
 
 import networkx as nx
 from networkx.algorithms import isomorphism
@@ -40,24 +41,31 @@ class SMARTSGraph(nx.Graph):
         else:
             self.ast = parser.parse(smarts_string)
 
+        self._atom_indices = OrderedDict()
         self._add_nodes()
         self._add_edges(self.ast)
         self._add_label_edges()
+        self._graph_matcher = None
 
     def _add_nodes(self):
         """Add all atoms in the SMARTS string as nodes in the graph."""
-        for atom in self.ast.select('atom'):
-            self.add_node(id(atom), atom=atom)
+        for n, atom in enumerate(self.ast.select('atom')):
+            self.add_node(n, atom=atom)
+            self._atom_indices[id(atom)] = n
 
     def _add_edges(self, ast_node, trunk=None):
         """"Add all bonds in the SMARTS string as edges in the graph."""
+        atom_indices = self._atom_indices
         for atom in ast_node.tail:
             if atom.head == 'atom':
+                atom_idx = atom_indices[id(atom)]
                 if atom.is_first_kid and atom.parent().head == 'branch':
-                    self.add_edge(id(atom), id(trunk))
+                    trunk_idx = atom_indices[id(trunk)]
+                    self.add_edge(atom_idx, trunk_idx)
                 if not atom.is_last_kid:
                     if atom.next_kid.head == 'atom':
-                        self.add_edge(id(atom), id(atom.next_kid))
+                        next_idx = atom_indices[id(atom.next_kid)]
+                        self.add_edge(atom_idx, next_idx)
                     elif atom.next_kid.head == 'branch':
                         trunk = atom
                 else:  # We traveled through the whole branch.
@@ -80,7 +88,9 @@ class SMARTSGraph(nx.Graph):
                 label_digits[digit].append(label.parent())
 
         for label, (atom1, atom2) in label_digits.items():
-            self.add_edge(id(atom1), id(atom2))
+            atom1_idx = self._atom_indices[id(atom1)]
+            atom2_idx = self._atom_indices[id(atom2)]
+            self.add_edge(atom1_idx, atom2_idx)
 
     def _node_match(self, host, pattern):
         atom_expr = pattern['atom'].tail[0]
@@ -162,14 +172,25 @@ class SMARTSGraph(nx.Graph):
         top_graph.add_edges_from(((b[0].index, b[1].index)
                                   for b in topology.bonds()))
 
-        graph_matcher = isomorphism.GraphMatcher(
-            top_graph, self, node_match=self._node_match)
+        if self._graph_matcher is None:
+            atom = nx.get_node_attributes(self, 'atom')[0]
+            try:
+                element = atom.select('atom_symbol').strees[0].tail[0]
+            except IndexError:
+                try:
+                    atomic_num = atom.select('atomic_num').strees[0].tail[0]
+                    element = pt.Element[int(atomic_num)]
+                except IndexError:
+                    element = None
+            self._graph_matcher = SMARTSMatcher(top_graph, self,
+                                                node_match=self._node_match,
+                                                element=element)
 
         # The first node in the smarts graph always corresponds to the atom
         # that we are trying to match.
         first_atom = next(self.nodes_iter())
         matched_atoms = set()
-        for mapping in graph_matcher.subgraph_isomorphisms_iter():
+        for mapping in self._graph_matcher.subgraph_isomorphisms_iter():
             mapping = {node_id: atom_id for atom_id, node_id in mapping.items()}
             atom_index = mapping[first_atom]
             # Don't yield duplicate matches found via matching the pattern in a
@@ -177,6 +198,41 @@ class SMARTSGraph(nx.Graph):
             if atom_index not in matched_atoms:
                 matched_atoms.add(atom_index)
                 yield atom_index
+
+
+class SMARTSMatcher(isomorphism.vf2userfunc.GraphMatcher):
+    def __init__(self, G1, G2, node_match, element):
+        super(SMARTSMatcher, self).__init__(G1, G2, node_match)
+        self.element = element
+        if element not in [None, '*']:
+            self.valid_nodes = [n for n, atom in nx.get_node_attributes(G1, 'atom').items()
+                                if atom.element.symbol == element]
+        else:
+            self.valid_nodes = G1.nodes()
+
+    def candidate_pairs_iter(self):
+        """Iterator over candidate pairs of nodes in G1 and G2."""
+        # All computations are done using the current state!
+        G2_nodes = self.G2_nodes
+
+        # First we compute the inout-terminal sets.
+        T1_inout = set(self.inout_1.keys()) - set(self.core_1.keys())
+        T2_inout = set(self.inout_2.keys()) - set(self.core_2.keys())
+
+        # If T1_inout and T2_inout are both nonempty.
+        # P(s) = T1_inout x {min T2_inout}
+        if T1_inout and T2_inout:
+            for node in T1_inout:
+                yield node, min(T2_inout)
+        else:
+            # First we determine the candidate node for G2
+            other_node = min(G2_nodes - set(self.core_2))
+            host_nodes = self.valid_nodes if other_node == 0 else self.G1.nodes()
+            for node in host_nodes:
+                if node not in self.core_1:
+                    yield node, other_node
+
+        # For all other cases, we don't have any candidate pairs.
 
 
 def _prepare_atoms(topology, compute_cycles=False):
@@ -202,3 +258,22 @@ def _prepare_atoms(topology, compute_cycles=False):
         for cycle in cycles:
             for atom in cycle:
                 atom.cycles.add(tuple(cycle))
+
+if __name__ == '__main__':
+    from foyer.smarts import SMARTS
+    from foyer.forcefield import generate_topology, Forcefield
+    import mbuild as mb
+    from mbuild.examples import Alkane
+
+    c6 = Alkane(n=6)
+    box = mb.fill_box(c6, 20, [10, 10, 10])
+
+
+    ff = Forcefield(name='oplsaa')
+
+    import time
+
+    start = time.time()
+    ff.apply(box)
+    print(time.time() - start)
+

--- a/foyer/smarts_graph.py
+++ b/foyer/smarts_graph.py
@@ -174,14 +174,17 @@ class SMARTSGraph(nx.Graph):
 
         if self._graph_matcher is None:
             atom = nx.get_node_attributes(self, 'atom')[0]
-            try:
-                element = atom.select('atom_symbol').strees[0].tail[0]
-            except IndexError:
+            if len(atom.select('atom_symbol')) == 1 and not atom.select('not_expression'):
                 try:
-                    atomic_num = atom.select('atomic_num').strees[0].tail[0]
-                    element = pt.Element[int(atomic_num)]
+                    element = atom.select('atom_symbol').strees[0].tail[0]
                 except IndexError:
-                    element = None
+                    try:
+                        atomic_num = atom.select('atomic_num').strees[0].tail[0]
+                        element = pt.Element[int(atomic_num)]
+                    except IndexError:
+                        element = None
+            else:
+                element = None
             self._graph_matcher = SMARTSMatcher(top_graph, self,
                                                 node_match=self._node_match,
                                                 element=element)

--- a/foyer/tests/test_graph.py
+++ b/foyer/tests/test_graph.py
@@ -20,8 +20,8 @@ def test_init():
     for smarts in TEST_BANK:
         graph = SMARTSGraph(smarts)
         atoms = graph.ast.select('atom')
-        for atom in atoms:
-            assert id(atom) in graph.nodes()
+        for n, atom in enumerate(atoms):
+            assert n in graph.nodes()
 
 
 def test_lazy_cycle_finding():

--- a/foyer/tests/test_smarts.py
+++ b/foyer/tests/test_smarts.py
@@ -121,14 +121,14 @@ def test_precedence():
     mol2 = pmd.load_file(get_fn('ethane.mol2'), structure=True)
     top, _ = generate_topology(mol2)
 
-    checks = {'[C,O;C]': True,
-              '[C&O;C]': False,
-              '[!C;O,C]': False,
-              '[!C&O,C]': True,
+    checks = {'[C,O;C]': 2,
+              '[C&O;C]': 0,
+              '[!C;O,C]': 0,
+              '[!C&O,C]': 2,
               }
 
     for smart, result in checks.items():
-        _rule_match(top, smart, result)
+        _rule_match_count(top, smart, result)
 
 
 def test_not_ast():

--- a/foyer/tests/test_smarts.py
+++ b/foyer/tests/test_smarts.py
@@ -16,6 +16,11 @@ def _rule_match(top, smart, result):
     assert bool(list(rule.find_matches(top))) is result
 
 
+def _rule_match_count(top, smart, count):
+    rule = SMARTSGraph(name='test', parser=PARSER, smarts_string=smart)
+    assert len(list(rule.find_matches(top))) is count
+
+
 def test_ast():
     ast = PARSER.parse('O([H&X1])(H)')
     assert ast.head == "start"
@@ -86,6 +91,8 @@ def test_ring_count():
     ring = pmd.load_file(get_fn('ring.mol2'), structure=True)
     top, _ = generate_topology(ring)
 
+    rule = SMARTSGraph(name='test', parser=PARSER,
+                       smarts_string='[#6;R1]')
     match_indices = list(rule.find_matches(top))
     for atom_idx in range(6):
         assert atom_idx in match_indices
@@ -144,15 +151,15 @@ def test_not():
     mol2 = pmd.load_file(get_fn('ethane.mol2'), structure=True)
     top, _ = generate_topology(mol2)
 
-    checks = {'[!O]': True,
-              '[!#5]': True,
-              '[!C]': True,
-              '[!#6]': True,
-              '[!C&!H]': False,
-              '[!C;!H]': False,
+    checks = {'[!O]': 8,
+              '[!#5]': 8,
+              '[!C]': 6,
+              '[!#6]': 6,
+              '[!C&!H]': 0,
+              '[!C;!H]': 0,
               }
     for smart, result in checks.items():
-        _rule_match(top, smart, result)
+        _rule_match_count(top, smart, result)
 
 
 def test_hexa_coordinated():


### PR DESCRIPTION
* Only perform graph matching starting with the first atom_expression in a SMARTS
* Only run rules on specified elements when possible
  * Currently no optimization is performed for rules that contain a not_expression or contain multiple atom_symbols in the first atom_expression