### PR TITLE
Pass residue information from Parmed Structure to OpenMM Topology

### DIFF
--- a/docs/usage_examples.md
+++ b/docs/usage_examples.md
@@ -47,7 +47,7 @@ the ethane.  The two atomtyped Parmed structures are then combined using a simpl
 '\+' operator and can be saved to Gromacs files.
 ```python
 from foyer import Forcefield
-from foyer.test.utils import get_fn
+from foyer.tests.utils import get_fn
 import mbuild as mb
 from mbuild.examples import Ethane
 from mbuild.lib.atoms import H

--- a/foyer/forcefield.py
+++ b/foyer/forcefield.py
@@ -83,8 +83,11 @@ def generate_topology(non_omm_topology, non_element_types=None):
 def _topology_from_parmed(structure, non_element_types):
     """Convert a ParmEd Structure to an OpenMM Topology."""
     topology = app.Topology()
-    chain = topology.addChain()
-    residue = topology.addResidue(structure.title, chain)
+    residues = dict()
+    for pmd_residue in structure.residues:
+        chain = topology.addChain()
+        omm_residue = topology.addResidue(pmd_residue.name, chain)
+        residues[pmd_residue] = omm_residue
     atoms = dict()  # pmd.Atom: omm.Atom
 
     for pmd_atom in structure.atoms:
@@ -98,7 +101,7 @@ def _topology_from_parmed(structure, non_element_types):
             else:
                 element = elem.Element.getBySymbol(pmd_atom.name)
 
-        omm_atom = topology.addAtom(name, element, residue)
+        omm_atom = topology.addAtom(name, element, residues[pmd_atom.residue])
         atoms[pmd_atom] = omm_atom
         omm_atom.bond_partners = []
 

--- a/foyer/tests/test_forcefield.py
+++ b/foyer/tests/test_forcefield.py
@@ -69,3 +69,11 @@ def test_write_refs():
     oplsaa = Forcefield(name='oplsaa')
     ethane = oplsaa.apply(mol2, references_file='ethane.bib')
     assert os.path.isfile('ethane.bib')
+
+def test_preserve_resname():
+    untyped_ethane = pmd.load_file(get_fn('ethane.mol2'), structure=True)
+    untyped_resname = untyped_ethane.residues[0].name
+    oplsaa = Forcefield(name='oplsaa')
+    typed_ethane = oplsaa.apply(untyped_ethane)
+    typed_resname = typed_ethane.residues[0].name
+    assert typed_resname == untyped_resname


### PR DESCRIPTION
This preserves residue information during atomtyping.  Previously all atoms were lumped into a single residue.