### PR TITLE
Changed "class" for atomtypes 151, 152, 153 on 'oplsaa.xml'

### DIFF
--- a/foyer/forcefields/oplsaa.xml
+++ b/foyer/forcefields/oplsaa.xml
@@ -148,9 +148,9 @@
   <Type name="opls_148" class="CT" element="C" mass="12.01100"   def="[C;X4]([C;%opls_145])(H)(H)H" desc="toluene CH3" overrides="opls_149,opls_135" doi="10.1021/ja9621760"/>
   <Type name="opls_149" class="CT" element="C" mass="12.01100"   def="[C;X4]([C;%opls_145])(H)(H)*" desc="ethyl benzene CH2" overrides="opls_136" doi="10.1021/ja9621760"/>
   <Type name="opls_150" class="opls_150" element="C" mass="12.011"/>
-  <Type name="opls_151" class="opls_151" element="Cl" mass="35.453"    def="[Cl][C;X4]" desc="Cl in alkyl chlorides"  />
-  <Type name="opls_152" class="opls_152" element="C" mass="12.011"   def="[C;X4](Cl)([Cl,C,H])([Cl,C,H])([Cl,C,H])" desc="RCH2Cl in alkyl chlorides"  />
-  <Type name="opls_153" class="opls_153" element="H" mass="1.008"    def="[H][C;X4](Cl)([Cl,C,H])([Cl,C,H])" overrides="opls_140" desc="H in alkyl chlorides"  />
+  <Type name="opls_151" class="Cl" element="Cl" mass="35.453"    def="[Cl][C;X4]" desc="Cl in alkyl chlorides"  />
+  <Type name="opls_152" class="CT" element="C" mass="12.011"   def="[C;X4](Cl)([Cl,C,H])([Cl,C,H])([Cl,C,H])" desc="RCH2Cl in alkyl chlorides"  />
+  <Type name="opls_153" class="HC" element="H" mass="1.008"    def="[H][C;X4](Cl)([Cl,C,H])([Cl,C,H])" overrides="opls_140" desc="H in alkyl chlorides"  />
   <Type name="opls_154" class="OH" element="O" mass="15.9994"   def="[O;X2]H" desc="all-atom O: mono alcohols" doi="10.1021/ja9621760"/>
   <Type name="opls_155" class="HO" element="H" mass="1.00800"   def="H[O;%opls_154]" desc="all-atom H(O): mono alcohols, OP(=O)2" doi="10.1021/ja9621760"/>
   <Type name="opls_156" class="HC" element="H" mass="1.008" def="HC(H)(H)OH" desc="all-atom H(C): methanol" overrides="opls_140" doi="10.1021/ja9621760"/>

--- a/foyer/version.py
+++ b/foyer/version.py
@@ -1,0 +1,7 @@
+
+# This file is generated in setup.py at build time.
+version = '0.3.1'
+short_version = '0.3.1'
+full_version = '0.3.1'
+git_revision = '1271e10973d4741b3b9a7a0ec3f4c2b3d9ae0052'
+release = True

--- a/foyer/version.py
+++ b/foyer/version.py
@@ -1,7 +1,0 @@
-
-# This file is generated in setup.py at build time.
-version = '0.3.1'
-short_version = '0.3.1'
-full_version = '0.3.1'
-git_revision = '1271e10973d4741b3b9a7a0ec3f4c2b3d9ae0052'
-release = True


### PR DESCRIPTION
The "class" on opls_151, opls_152, and opls_153 SMARTS strings were updated.  This should fix missing bond information for alkyl chlorides.