### PR TITLE
Limiting cycle size to less than 8 atoms

### DIFF
--- a/foyer/smarts_graph.py
+++ b/foyer/smarts_graph.py
@@ -259,5 +259,8 @@ def _prepare_atoms(topology, compute_cycles=False):
         bond_graph.add_edges_from(topology.bonds())
         cycles = nx.cycle_basis(bond_graph)
         for cycle in cycles:
+            # NOTE: Only considering cycles containing less than 8 atoms
+            if len(cycle) > 8:
+                continue
             for atom in cycle:
                 atom.cycles.add(tuple(cycle))


### PR DESCRIPTION
Only keep track of cycles atoms are in if the cycles contain less than 8 atoms (if we feel there is a need to make this number larger we can certainly do so).  This helps to speed up the atom-typing process so that Foyer isn't spending time looping over cycles that may be thousands of atoms long, such as in the case of a surface.