### PR TITLE
Avoid duplicate residue atomptying

### DIFF
--- a/foyer/forcefield.py
+++ b/foyer/forcefield.py
@@ -166,7 +166,7 @@ def _check_independent_residues(topology):
     return True
 
 
-def _update_atomtypes(unatomtyped_topology, prototype):
+def _update_atomtypes(unatomtyped_topology, res_name, prototype):
     """Update atomtypes in residues in a topology using a prototype topology.
 
     Atomtypes are updated when residues in each topology have matching names.
@@ -180,11 +180,9 @@ def _update_atomtypes(unatomtyped_topology, prototype):
 
     """
     for res in unatomtyped_topology.residues():
-        if res.name == [res_prototype.name for res_prototype in prototype.residues()][0]:
+        if res.name == res_name:
             for old_atom, new_atom_id in zip([atom for atom in res.atoms()], [atom.id for atom in prototype.atoms()]):
                 old_atom.id = new_atom_id
-    atomtyped_topology = unatomtyped_topology
-    return atomtyped_topology
 
 
 class Forcefield(app.ForceField):
@@ -382,12 +380,8 @@ class Forcefield(app.ForceField):
                             find_atomtypes(residue, forcefield=self)
                             residue_map[res.name] = residue
 
-                    new_topology = topology
-
                     for key, val in residue_map.items():
-                        new_topology = _update_atomtypes(topology, val)
-
-                    topology = new_topology
+                        _update_atomtypes(topology, key, val)
 
                 else:
                     find_atomtypes(topology, forcefield=self)

--- a/foyer/tests/test_forcefield.py
+++ b/foyer/tests/test_forcefield.py
@@ -3,11 +3,13 @@ import os
 from pkg_resources import resource_filename
 
 import mbuild as mb
+from mbuild.examples import Alkane
 import parmed as pmd
 import pytest
 
 from foyer import Forcefield
 from foyer.forcefield import generate_topology
+from foyer.forcefield import _check_independent_residues
 from foyer.tests.utils import get_fn
 
 
@@ -111,10 +113,26 @@ def test_improper_dihedral():
 
 def test_residue_map():
     ethane = pmd.load_file(get_fn('ethane.mol2'), structure=True)
+    ethane *= 2
     oplsaa = Forcefield(name='oplsaa')
     topo, NULL = generate_topology(ethane)
     with_map = pmd.openmm.load_topology(topo,
-        oplsaa.createSystem(topo, use_residue_map = True))
+            oplsaa.createSystem(topo, use_residue_map=True))
     without_map = pmd.openmm.load_topology(topo,
-        oplsaa.createSystem(topo, use_residue_map = False))
-    [a.type for a in with_map.atoms] == [a.type for a in without_map.atoms]
+            oplsaa.createSystem(topo, use_residue_map=False))
+    for atom_with, atom_without in zip(with_map.atoms, without_map.atoms):
+        assert atom_with.type == atom_without.type
+        b_with = atom_with.bond_partners
+        b_without = atom_without.bond_partners
+        assert [a0.type for a0 in b_with] == [a1.type for a1 in b_without]
+        assert [a0.idx for a0 in b_with] == [a1.idx for a1 in b_without]
+
+def test_independent_residues():
+    """Test to see that _check_independent_residues works."""
+    butane = Alkane(4)
+    structure = butane.to_parmed()
+    topo, NULL = generate_topology(structure)
+    assert _check_independent_residues(topo)
+    structure = butane.to_parmed(residues=['RES', 'CH3'])
+    topo, NULL = generate_topology(structure)
+    assert not _check_independent_residues(topo)


### PR DESCRIPTION
Big thanks to @summeraz and @justinGilmer for codemonkey-ing this out.

Currently, each residue in a system is atomtyped even if an identical residue was previously atomtyped. For example, the current atomtyper would atomtype each water in a million-water system, which is a waste of time for larger systems. The approach here is to create a map of unique, already-atomtyped residues, so the 2nd to Nth residue don't call the subgraph isomorphism routines and instead look back at a prototype that was added to the map when it was first found.

* It appears to not be possible to slice ```openmm.app.Topology``` so I wrote a helper function that takes a ```openmm.app.Topology.Residue``` and returns an otherwise-identical ```openmm.app.Topology```. This could be done cleaner if slicing is implemented in the future. This can casually be done in ```ParmEd``` but we found it to be expensive and unnecessary to move between the two types. We tested a number of different combinations of going between the two, but found it was best to stay in openmm the entire time.

* The case of atoms in a residue being bonded to other residues is not trivial to handle, so I added a check for this, and then use the current atomtyping method if this is the case. We might want to revisit this for large polymer or protein systems, but this works fine when so-called "residues" are actually separate molecules.

There is still some overhead associated with this method, but the result is much cheaper for these types of systems. I have done some benchmarking on a system of butane molecules to show this:

![image](https://user-images.githubusercontent.com/7935382/29254921-dddb4342-8061-11e7-8166-67e436a0a7b4.png)


The "brute-force" curve is from the current master branch and "with-residues" is from this branch. I was unable to run the 100,000 residue systems, even on the Rahman head node, due to memory issues. The speedup converges to a factor of about 20, which I suspect could be improved upon in the future. The linear scaling is a bit of a concern, but I haven't gotten to the bottom of it yet.