### PR TITLE
Quiet output for missing atom types

### DIFF
--- a/foyer/forcefield.py
+++ b/foyer/forcefield.py
@@ -197,7 +197,7 @@ class Forcefield(app.ForceField):
 
 
     """
-    def __init__(self, forcefield_files=None, name=None, validation=True):
+    def __init__(self, forcefield_files=None, name=None, validation=True, debug=False):
         self.atomTypeDefinitions = dict()
         self.atomTypeOverrides = dict()
         self.atomTypeDesc = dict()
@@ -224,7 +224,7 @@ class Forcefield(app.ForceField):
         preprocessed_files = preprocess_forcefield_files(all_files_to_load)
         if validation:
             for ff_file_name in preprocessed_files:
-                Validator(ff_file_name)
+                Validator(ff_file_name, debug)
 
         super(Forcefield, self).__init__(*preprocessed_files)
         self.parser = smarts.SMARTS(self.non_element_types)

--- a/foyer/validator.py
+++ b/foyer/validator.py
@@ -13,7 +13,7 @@ from foyer.smarts_graph import SMARTSGraph
 
 
 class Validator(object):
-    def __init__(self, ff_file_name):
+    def __init__(self, ff_file_name, debug=False):
         from foyer.forcefield import preprocess_forcefield_files
         preprocessed_ff_file_name = preprocess_forcefield_files([ff_file_name])
 
@@ -30,7 +30,7 @@ class Validator(object):
         from foyer.forcefield import Forcefield
         self.smarts_parser = Forcefield(preprocessed_ff_file_name, validation=False).parser
 
-        self.validate_smarts()
+        self.validate_smarts(debug=debug)
         self.validate_overrides()
 
     @staticmethod
@@ -115,7 +115,7 @@ class Validator(object):
                         errors.append(error)
         raise_collected(errors)
 
-    def validate_smarts(self):
+    def validate_smarts(self, debug):
         missing_smarts = []
         errors = []
         for entry in self.atom_types:
@@ -154,9 +154,13 @@ class Validator(object):
                             None, entry.sourceline)
                         errors.append(undefined)
         raise_collected(errors)
-        if missing_smarts:
+        if missing_smarts and debug:
             warn("The following atom types do not have smarts definitions: {}".format(
                 ', '.join(missing_smarts)), ValidationWarning)
+       	if missing_smarts and not debug:
+       	    warn("There are {} atom types that are missing a smarts definition. "
+                     "To view the missing atom types, re-run with debug=True when "
+                     "applying the forcefield.".format(len(missing_smarts)), ValidationWarning)
 
     def validate_overrides(self):
         errors = []

--- a/foyer/validator.py
+++ b/foyer/validator.py
@@ -157,7 +157,7 @@ class Validator(object):
         if missing_smarts and debug:
             warn("The following atom types do not have smarts definitions: {}".format(
                 ', '.join(missing_smarts)), ValidationWarning)
-       	if missing_smarts and not debug:
+        if missing_smarts and not debug:
        	    warn("There are {} atom types that are missing a smarts definition. "
                      "To view the missing atom types, re-run with debug=True when "
                      "applying the forcefield.".format(len(missing_smarts)), ValidationWarning)


### PR DESCRIPTION
Previously, when applying a forcefield with many missing atom types
in the forcefield XML, `foyer` would output as a warning all the
missing atom types to the user upon successfully atom typing.

For the larger forcefield files (`oplsaa.xml` for example), there are currently
~750 missing atom types that do not have a smarts string. This led to cumbersome
warning messages.

Now, the default behavior for missing atom types is to still warn the user, but
condense the information to ~2 lines of output.

If the user wants to know which atom types are missing a smarts string,
a debug flag can be passed during the application of the forcefield to
revert to the previous behavior.