### PR TITLE
Fix homebrew Ruby error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ env:
   - COMMIT_AUTHOR_EMAIL: "janos.sallai@vanderbilt.edu"
 
 install:
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install md5sha1sum; fi
   - source devtools/travis-ci/install_conda.sh
   - conda config --set always_yes yes --set changeps1 no


### PR DESCRIPTION
There is an issue wth homebrew and the ruby version on osx that
causes homebrew to fail for all travis builds currently.

Forcing homebrew to update before installing packages fixes this issue.