### PR TITLE
NetworkX migration

### DIFF
--- a/foyer/smarts_graph.py
+++ b/foyer/smarts_graph.py
@@ -154,7 +154,7 @@ class SMARTSGraph(nx.Graph):
         When this function gets used in atomtyper.py, we actively modify the
         white- and blacklists of the atoms in `topology` after finding a match.
         This means that between every successive call of
-        `subgraph_isomorphisms()`, the topology against which we are
+        `subgraph_isomorphisms_iter()`, the topology against which we are
         matching may have actually changed. Currently, we take advantage of this
         behavior in some edges cases (e.g. see `test_hexa_coordinated` in
         `test_smarts.py`).
@@ -193,7 +193,7 @@ class SMARTSGraph(nx.Graph):
         # that we are trying to match.
         first_atom = self.nodes()[0]
         matched_atoms = set()
-        for mapping in self._graph_matcher.subgraph_isomorphisms():
+        for mapping in self._graph_matcher.subgraph_isomorphisms_iter():
             mapping = {node_id: atom_id for atom_id, node_id in mapping.items()}
             atom_index = mapping[first_atom]
             # Don't yield duplicate matches found via matching the pattern in a

--- a/foyer/smarts_graph.py
+++ b/foyer/smarts_graph.py
@@ -189,11 +189,11 @@ class SMARTSGraph(nx.Graph):
                                                 node_match=self._node_match,
                                                 element=element)
 
-        # The first node in the smarts graph always corresponds to the atom
-        # that we are trying to match.
         matched_atoms = set()
         for mapping in self._graph_matcher.subgraph_isomorphisms_iter():
             mapping = {node_id: atom_id for atom_id, node_id in mapping.items()}
+            # The first node in the smarts graph always corresponds to the atom
+            # that we are trying to match.
             atom_index = mapping[0]
             # Don't yield duplicate matches found via matching the pattern in a
             # different order.

--- a/foyer/smarts_graph.py
+++ b/foyer/smarts_graph.py
@@ -191,11 +191,10 @@ class SMARTSGraph(nx.Graph):
 
         # The first node in the smarts graph always corresponds to the atom
         # that we are trying to match.
-        first_atom = self.nodes()[0]
         matched_atoms = set()
         for mapping in self._graph_matcher.subgraph_isomorphisms_iter():
             mapping = {node_id: atom_id for atom_id, node_id in mapping.items()}
-            atom_index = mapping[first_atom]
+            atom_index = mapping[0]
             # Don't yield duplicate matches found via matching the pattern in a
             # different order.
             if atom_index not in matched_atoms:

--- a/foyer/smarts_graph.py
+++ b/foyer/smarts_graph.py
@@ -191,7 +191,7 @@ class SMARTSGraph(nx.Graph):
 
         # The first node in the smarts graph always corresponds to the atom
         # that we are trying to match.
-        first_atom = next(self.nodes())
+        first_atom = self.nodes()[0]
         matched_atoms = set()
         for mapping in self._graph_matcher.subgraph_isomorphisms():
             mapping = {node_id: atom_id for atom_id, node_id in mapping.items()}

--- a/foyer/smarts_graph.py
+++ b/foyer/smarts_graph.py
@@ -173,7 +173,7 @@ class SMARTSGraph(nx.Graph):
                                   for b in topology.bonds()))
 
         if self._graph_matcher is None:
-            atom = nx.get_node_attributes(self, 'atom')[0]
+            atom = nx.get_node_attributes(self, name='atom')[0]
             if len(atom.select('atom_symbol')) == 1 and not atom.select('not_expression'):
                 try:
                     element = atom.select('atom_symbol').strees[0].tail[0]
@@ -208,7 +208,7 @@ class SMARTSMatcher(isomorphism.vf2userfunc.GraphMatcher):
         super(SMARTSMatcher, self).__init__(G1, G2, node_match)
         self.element = element
         if element not in [None, '*']:
-            self.valid_nodes = [n for n, atom in nx.get_node_attributes(G1, 'atom').items()
+            self.valid_nodes = [n for n, atom in nx.get_node_attributes(G1, name='atom').items()
                                 if atom.element.symbol == element]
         else:
             self.valid_nodes = G1.nodes()

--- a/foyer/smarts_graph.py
+++ b/foyer/smarts_graph.py
@@ -154,7 +154,7 @@ class SMARTSGraph(nx.Graph):
         When this function gets used in atomtyper.py, we actively modify the
         white- and blacklists of the atoms in `topology` after finding a match.
         This means that between every successive call of
-        `subgraph_isomorphisms_iter()`, the topology against which we are
+        `subgraph_isomorphisms()`, the topology against which we are
         matching may have actually changed. Currently, we take advantage of this
         behavior in some edges cases (e.g. see `test_hexa_coordinated` in
         `test_smarts.py`).
@@ -191,9 +191,9 @@ class SMARTSGraph(nx.Graph):
 
         # The first node in the smarts graph always corresponds to the atom
         # that we are trying to match.
-        first_atom = next(self.nodes_iter())
+        first_atom = next(self.nodes())
         matched_atoms = set()
-        for mapping in self._graph_matcher.subgraph_isomorphisms_iter():
+        for mapping in self._graph_matcher.subgraph_isomorphisms():
             mapping = {node_id: atom_id for atom_id, node_id in mapping.items()}
             atom_index = mapping[first_atom]
             # Don't yield duplicate matches found via matching the pattern in a

--- a/foyer/validator.py
+++ b/foyer/validator.py
@@ -143,7 +143,7 @@ class Validator(object):
             # make sure referenced labels exist
             smarts_graph = SMARTSGraph(smarts_string, parser=self.smarts_parser,
                                        name=name, overrides=entry.attrib.get('overrides'))
-            for atom_expr in nx.get_node_attributes(smarts_graph, 'atom').values():
+            for atom_expr in nx.get_node_attributes(smarts_graph, name='atom').values():
                 labels = atom_expr.select('has_label')
                 for label in labels:
                     atom_type = label.tail[0][1:]


### PR DESCRIPTION
Several functions and function names have changed from NetworkX 1.0 to NetworkX 2.0. For example, the `Graph.nodes_iter()` function has been replaced by `Graph.nodes()`. This PR changes our NetworkX syntax to conform to both versions.