### PR TITLE
Allow single-atom residues to use the residue map

### DIFF
--- a/foyer/forcefield.py
+++ b/foyer/forcefield.py
@@ -162,7 +162,7 @@ def _check_independent_residues(topology):
         atoms_in_residue = set([atom for atom in res.atoms()])
         bond_partners_in_residue = [item for sublist in [atom.bond_partners for atom in res.atoms()] for item in sublist]
         # Handle the case of a 'residue' with no neighbors
-        if bond_partners_in_residue is None:
+        if not bond_partners_in_residue:
             continue
         if set(atoms_in_residue) != set(bond_partners_in_residue):
             return False

--- a/foyer/forcefield.py
+++ b/foyer/forcefield.py
@@ -161,6 +161,9 @@ def _check_independent_residues(topology):
     for res in topology.residues():
         atoms_in_residue = set([atom for atom in res.atoms()])
         bond_partners_in_residue = [item for sublist in [atom.bond_partners for atom in res.atoms()] for item in sublist]
+        # Handle the case of a 'residue' with no neighbors
+        if bond_partners_in_residue is None:
+            continue
         if set(atoms_in_residue) != set(bond_partners_in_residue):
             return False
     return True

--- a/foyer/tests/test_forcefield.py
+++ b/foyer/tests/test_forcefield.py
@@ -127,8 +127,8 @@ def test_residue_map():
         assert [a0.type for a0 in b_with] == [a1.type for a1 in b_without]
         assert [a0.idx for a0 in b_with] == [a1.idx for a1 in b_without]
 
-def test_independent_residues():
-    """Test to see that _check_independent_residues works."""
+def test_independent_residues_molecules():
+    """Test to see that _check_independent_residues works for molecules."""
     butane = Alkane(4)
     structure = butane.to_parmed()
     topo, NULL = generate_topology(structure)
@@ -136,3 +136,11 @@ def test_independent_residues():
     structure = butane.to_parmed(residues=['RES', 'CH3'])
     topo, NULL = generate_topology(structure)
     assert not _check_independent_residues(topo)
+
+def test_independent_residues_atoms():
+    """Test to see that _check_independent_residues works for single aotms."""
+    argon = mb.Compound()
+    argon.name = 'Ar'
+    structure = argon.to_parmed()
+    topo, NULL = generate_topology(structure)
+    assert _check_independent_residues(topo)


### PR DESCRIPTION
The `_check_independent_residues` function, which needs to be `True` in order to use the residue map feature I added a while back, breaks if the atoms in the residue have no bond partners. The function checks to see if any bond partners of atoms in a given residue are not themselves atom in said residue:

```
if set(atoms_in_residue) != set(bond_partners_in_residue):
    return False
```
But this was breaking when `bond_partners_in_residue` is an empty list.

This small fix handles this case, and should allow single-atom residues to use the residue map for speedup in atomtyping.

h/t @justinGilmer, who found this by way of an argon system that was slow to apply a force field to.