### PR TITLE
Move atomtyping step into a specific function

### DIFF
--- a/foyer/forcefield.py
+++ b/foyer/forcefield.py
@@ -309,7 +309,14 @@ class Forcefield(app.ForceField):
             Name of file where force field references will be written (in Bibtex
             format)
         use_residue_map : boolean
-            Bypass atomtyping duplicate residues using a residue map
+            Store atomtyped topologies of residues to a dictionary that maps
+            them to residue names.  Each topology, including atomtypes, will be
+            copied to other residues with the same name. This avoids repeatedly
+            calling the subgraph isomorphism on idential residues and should
+            result in better performance for systems with many identital
+            residues, i.e. a box of water. Note that for this to be applied to
+            independent molecules, they must each be saved as different
+            residues in the topology.
         """
         if not isinstance(topology, app.Topology):
             residues = kwargs.get('residues')
@@ -341,7 +348,14 @@ class Forcefield(app.ForceField):
         topology : openmm.app.Topology
             Molecular structure to find atom types of
         use_residue_map : boolean
-            Bypass atomtyping duplicate residues using a residue map
+            Store atomtyped topologies of residues to a dictionary that maps
+            them to residue names.  Each topology, including atomtypes, will be
+            copied to other residues with the same name. This avoids repeatedly
+            calling the subgraph isomorphism on idential residues and should
+            result in better performance for systems with many identital
+            residues, i.e. a box of water. Note that for this to be applied to
+            independent molecules, they must each be saved as different
+            residues in the topology.
         """
         if use_residue_map:
             independent_residues = _check_independent_residues(topology)

--- a/foyer/forcefield.py
+++ b/foyer/forcefield.py
@@ -383,8 +383,7 @@ class Forcefield(app.ForceField):
 
         return topology
 
-    def createSystem(self, topology, atomtype=True, use_residue_map=True,
-                     nonbondedMethod=NoCutoff,
+    def createSystem(self, topology, nonbondedMethod=NoCutoff,
                      nonbondedCutoff=1.0 * u.nanometer, constraints=None,
                      rigidWater=True, removeCMMotion=True, hydrogenMass=None,
                      **args):
@@ -394,8 +393,6 @@ class Forcefield(app.ForceField):
         ----------
         topology : Topology
             The Topology for which to create a System
-        use_residue_map : boolean
-            Bypass atomtyping duplicate residues using a residue map
         nonbondedMethod : object=NoCutoff
             The method to use for nonbonded interactions.  Allowed values are
             NoCutoff, CutoffNonPeriodic, CutoffPeriodic, Ewald, or PME.

--- a/foyer/forcefield.py
+++ b/foyer/forcefield.py
@@ -330,6 +330,31 @@ class Forcefield(app.ForceField):
 
         return structure
 
+    def run_atomtyping(self, topology, use_residue_map):
+
+        if use_residue_map:
+            independent_residues = _check_independent_residues(topology)
+
+            if independent_residues:
+                residue_map = dict()
+
+                for res in topology.residues():
+                    if res.name not in residue_map.keys():
+                        residue = _topology_from_residue(res)
+                        find_atomtypes(residue, forcefield=self)
+                        residue_map[res.name] = residue
+
+                for key, val in residue_map.items():
+                    _update_atomtypes(topology, key, val)
+
+            else:
+                find_atomtypes(topology, forcefield=self)
+
+        else:
+            find_atomtypes(topology, forcefield=self)
+
+        return topology
+
     def createSystem(self, topology, atomtype=True, use_residue_map=True,
                      nonbondedMethod=NoCutoff,
                      nonbondedCutoff=1.0 * u.nanometer, constraints=None,
@@ -370,27 +395,6 @@ class Forcefield(app.ForceField):
         system
             the newly created System
         """
-        if atomtype:
-            if use_residue_map:
-                independent_residues = _check_independent_residues(topology)
-
-                if independent_residues:
-                    residue_map = dict()
-
-                    for res in topology.residues():
-                        if res.name not in residue_map.keys():
-                            residue = _topology_from_residue(res)
-                            find_atomtypes(residue, forcefield=self)
-                            residue_map[res.name] = residue
-
-                    for key, val in residue_map.items():
-                        _update_atomtypes(topology, key, val)
-
-                else:
-                    find_atomtypes(topology, forcefield=self)
-
-            else:
-                find_atomtypes(topology, forcefield=self)
 
         data = app.ForceField._SystemData()
         data.atoms = list(topology.atoms())

--- a/foyer/forcefield.py
+++ b/foyer/forcefield.py
@@ -317,6 +317,7 @@ class Forcefield(app.ForceField):
             positions = np.empty(shape=(topology.getNumAtoms(), 3))
             positions[:] = np.nan
         box_vectors = topology.getPeriodicBoxVectors()
+        topology = self.run_atomtyping(topology, use_residue_map=use_residue_map)
         system = self.createSystem(topology, *args, **kwargs)
 
         structure = pmd.openmm.load_topology(topology=topology, system=system)
@@ -330,7 +331,7 @@ class Forcefield(app.ForceField):
 
         return structure
 
-    def run_atomtyping(self, topology, use_residue_map):
+    def run_atomtyping(self, topology, use_residue_map=True):
 
         if use_residue_map:
             independent_residues = _check_independent_residues(topology)

--- a/foyer/forcefield.py
+++ b/foyer/forcefield.py
@@ -308,6 +308,8 @@ class Forcefield(app.ForceField):
         references_file : str, optional, default=None
             Name of file where force field references will be written (in Bibtex
             format)
+        use_residue_map : boolean
+            Bypass atomtyping duplicate residues using a residue map
         """
         if not isinstance(topology, app.Topology):
             residues = kwargs.get('residues')
@@ -332,7 +334,15 @@ class Forcefield(app.ForceField):
         return structure
 
     def run_atomtyping(self, topology, use_residue_map=True):
+        """Atomtype the topology
 
+        Parameters
+        ----------
+        topology : openmm.app.Topology
+            Molecular structure to find atom types of
+        use_residue_map : boolean
+            Bypass atomtyping duplicate residues using a residue map
+        """
         if use_residue_map:
             independent_residues = _check_independent_residues(topology)
 

--- a/foyer/forcefield.py
+++ b/foyer/forcefield.py
@@ -308,12 +308,12 @@ class Forcefield(app.ForceField):
         references_file : str, optional, default=None
             Name of file where force field references will be written (in Bibtex
             format)
-        use_residue_map : boolean
+        use_residue_map : boolean, optional, default=True
             Store atomtyped topologies of residues to a dictionary that maps
             them to residue names.  Each topology, including atomtypes, will be
             copied to other residues with the same name. This avoids repeatedly
             calling the subgraph isomorphism on idential residues and should
-            result in better performance for systems with many identital
+            result in better performance for systems with many identical
             residues, i.e. a box of water. Note that for this to be applied to
             independent molecules, they must each be saved as different
             residues in the topology.
@@ -347,12 +347,12 @@ class Forcefield(app.ForceField):
         ----------
         topology : openmm.app.Topology
             Molecular structure to find atom types of
-        use_residue_map : boolean
+        use_residue_map : boolean, optional, default=True
             Store atomtyped topologies of residues to a dictionary that maps
             them to residue names.  Each topology, including atomtypes, will be
             copied to other residues with the same name. This avoids repeatedly
             calling the subgraph isomorphism on idential residues and should
-            result in better performance for systems with many identital
+            result in better performance for systems with many identical
             residues, i.e. a box of water. Note that for this to be applied to
             independent molecules, they must each be saved as different
             residues in the topology.

--- a/foyer/forcefield.py
+++ b/foyer/forcefield.py
@@ -364,6 +364,9 @@ class Forcefield(app.ForceField):
         else:
             find_atomtypes(topology, forcefield=self)
 
+        if not all([a.id for a in topology.atoms()][0]):
+            raise ValueError('Not all atoms in topology have atom types')
+
         return topology
 
     def createSystem(self, topology, atomtype=True, use_residue_map=True,

--- a/foyer/forcefield.py
+++ b/foyer/forcefield.py
@@ -298,7 +298,7 @@ class Forcefield(app.ForceField):
         if 'doi' in parameters:
             self.atomTypeRefs[name] = parameters['doi']
 
-    def apply(self, topology, references_file=None, *args, **kwargs):
+    def apply(self, topology, references_file=None, use_residue_map=True, *args, **kwargs):
         """Apply the force field to a molecular structure
 
         Parameters

--- a/foyer/tests/test_forcefield.py
+++ b/foyer/tests/test_forcefield.py
@@ -116,11 +116,11 @@ def test_residue_map():
     ethane *= 2
     oplsaa = Forcefield(name='oplsaa')
     topo, NULL = generate_topology(ethane)
-    with_map = pmd.openmm.load_topology(topo,
-            oplsaa.createSystem(topo, use_residue_map=True))
-    without_map = pmd.openmm.load_topology(topo,
-            oplsaa.createSystem(topo, use_residue_map=False))
-    for atom_with, atom_without in zip(with_map.atoms, without_map.atoms):
+    topo_with = oplsaa.run_atomtyping(topo, use_residue_map=True)
+    topo_without = oplsaa.run_atomtyping(topo, use_residue_map=False)
+    struct_with = pmd.openmm.load_topology(topo_without, oplsaa.createSystem(topo_with))
+    struct_without = pmd.openmm.load_topology(topo_without, oplsaa.createSystem(topo_without))
+    for atom_with, atom_without in zip(struct_with.atoms, struct_without.atoms):
         assert atom_with.type == atom_without.type
         b_with = atom_with.bond_partners
         b_without = atom_without.bond_partners

--- a/foyer/tests/test_forcefield.py
+++ b/foyer/tests/test_forcefield.py
@@ -120,7 +120,7 @@ def test_residue_map():
     topo_without = oplsaa.run_atomtyping(topo, use_residue_map=False)
     assert all([a.id for a in topo_with.atoms()][0])
     assert all([a.id for a in topo_without.atoms()][0])
-    struct_with = pmd.openmm.load_topology(topo_without, oplsaa.createSystem(topo_with))
+    struct_with = pmd.openmm.load_topology(topo_with, oplsaa.createSystem(topo_with))
     struct_without = pmd.openmm.load_topology(topo_without, oplsaa.createSystem(topo_without))
     for atom_with, atom_without in zip(struct_with.atoms, struct_without.atoms):
         assert atom_with.type == atom_without.type

--- a/foyer/tests/test_forcefield.py
+++ b/foyer/tests/test_forcefield.py
@@ -118,6 +118,8 @@ def test_residue_map():
     topo, NULL = generate_topology(ethane)
     topo_with = oplsaa.run_atomtyping(topo, use_residue_map=True)
     topo_without = oplsaa.run_atomtyping(topo, use_residue_map=False)
+    assert all([a.id for a in topo_with.atoms()][0])
+    assert all([a.id for a in topo_without.atoms()][0])
     struct_with = pmd.openmm.load_topology(topo_without, oplsaa.createSystem(topo_with))
     struct_without = pmd.openmm.load_topology(topo_without, oplsaa.createSystem(topo_without))
     for atom_with, atom_without in zip(struct_with.atoms, struct_without.atoms):


### PR DESCRIPTION
Dicussed in #157, but to repeat the important bit:

Currently there's a bit of code at the beginning of `Forcefield.createSystem` that manages the atomtyping step, whereas this should more cleanly done by being sectioned off to a different function.

* I'm open to naming the function something more elegant, I'm not happy with `Forcefield.run_atomtyping` but couldn't come up with something better.

* I'm not sure if it should be a helper function, or whatever `Forcefield._run_atomtyping` would be called. It seems possible for a user to want to call it directly without creating the entire `openmm.System` or `parmed.Structure`.

* I don't think a test is necessary for this, as I'm just moving code around. But I also couldn't think of how a useful test would be structured. I could verify that the returned `openmm.Topology` has atomtype information, but this should cause later tests to crash anyway.

* I added `use_residue_map` as an argument to `Forcefield.apply`. I don't know why it wasn't there before, and don't see any reason for it to be buried inside these other functions.