### PR TITLE
Multiple DOIs per atomtype

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,4 +4,4 @@ graft examples
 include foyer/tests/implemented_opls_tests.txt
 graft foyer/trappe_validation
 include foyer/tests/implemented_trappe_tests.txt
-global-include *.xml *.mol2 *.top *.gro *.pdb
+global-include *.xml *.mol2 *.top *.gro *.pdb *.bib

--- a/foyer/forcefield.py
+++ b/foyer/forcefield.py
@@ -723,9 +723,9 @@ class Forcefield(app.ForceField):
                 warnings.warn("Reference not found for atom type '{}'."
                               "".format(atype))
         unique_references = collections.defaultdict(list)
-        for key, values in atomtype_references.items():
-            for doi in values:
-                unique_references[doi].append(key)
+        for atomtype, dois in atomtype_references.items():
+            for doi in dois:
+                unique_references[doi].append(atomtype)
         unique_references = collections.OrderedDict(sorted(unique_references.items()))
         with open(references_file, 'w') as f:
             for doi, atomtypes in unique_references.items():

--- a/foyer/forcefield.py
+++ b/foyer/forcefield.py
@@ -335,8 +335,7 @@ class Forcefield(app.ForceField):
         if 'des' in parameters:
             self.atomTypeDesc[name] = parameters['desc']
         if 'doi' in parameters:
-            dois = [doi.replace(',', '').strip() for doi
-                    in parameters['doi'].split(',')]
+            dois = set(doi.strip() for doi in parameters['doi'].split(','))
             self.atomTypeRefs[name] = dois
 
     def apply(self, topology, references_file=None, use_residue_map=True,

--- a/foyer/tests/files/ethane-multi.bib
+++ b/foyer/tests/files/ethane-multi.bib
@@ -1,0 +1,28 @@
+@article{Jorgensen_1996,
+	doi = {10.1021/ja9621760},
+	url = {https://doi.org/10.1021%2Fja9621760},
+	year = 1996,
+	month = {jan},
+	publisher = {American Chemical Society ({ACS})},
+	volume = {118},
+	number = {45},
+	pages = {11225--11236},
+	author = {William L. Jorgensen and David S. Maxwell and Julian Tirado-Rives},
+	title = {Development and Testing of the {OPLS} All-Atom Force Field on Conformational Energetics and Properties of Organic Liquids},
+	journal = {Journal of the American Chemical Society},
+	note = {Parameters for atom types: opls_135, opls_140}
+}
+@article{Jorgensen_2004,
+	doi = {10.1021/jp0484579},
+	url = {https://doi.org/10.1021%2Fjp0484579},
+	year = 2004,
+	month = {oct},
+	publisher = {American Chemical Society ({ACS})},
+	volume = {108},
+	number = {41},
+	pages = {16264--16270},
+	author = {William L. Jorgensen and Jakob P. Ulmschneider and Julian Tirado-Rives},
+	title = {Free Energies of Hydration from a Generalized Born Model and an All-Atom Force Field},
+	journal = {The Journal of Physical Chemistry B},
+	note = {Parameters for atom types: opls_135}
+}

--- a/foyer/tests/files/refs-multi.xml
+++ b/foyer/tests/files/refs-multi.xml
@@ -1,0 +1,21 @@
+ <ForceField>
+ <AtomTypes>
+    <Type name="opls_135" class="CT" element="C" mass="12.01100" def="[C;X4](C)(H)(H)H" desc="alkane CH3" doi="10.1021/ja9621760,10.1021/jp0484579"/>
+    <Type name="opls_140" class="HC" element="H" mass="1.00800" def="H[C;X4]" desc="alkane H" doi="10.1021/ja9621760"/>
+ </AtomTypes>
+ <HarmonicBondForce>
+    <Bond class1="CT" class2="CT" length="0.1529" k="224262.4"/>
+    <Bond class1="CT" class2="HC" length="0.109" k="284512.0"/>
+ </HarmonicBondForce>
+ <HarmonicAngleForce>
+    <Angle class1="CT" class2="CT" class3="HC" angle="1.93207948196" k="313.8"/>
+    <Angle class1="HC" class2="CT" class3="HC" angle="1.88146493365" k="276.144"/>
+ </HarmonicAngleForce>
+ <RBTorsionForce>
+    <Proper class1="HC" class2="CT" class3="CT" class4="HC" c0="0.6276" c1="1.8828" c2="0.0" c3="-2.5104" c4="0.0" c5="0.0"/>
+ </RBTorsionForce>
+ <NonbondedForce coulomb14scale="0.5" lj14scale="0.5">
+     <Atom type="opls_135" charge="-0.18" sigma="0.35" epsilon="0.276144"/>
+     <Atom type="opls_140" charge="0.06" sigma="0.25" epsilon="0.12552"/>
+ </NonbondedForce>
+</ForceField>

--- a/foyer/tests/test_forcefield.py
+++ b/foyer/tests/test_forcefield.py
@@ -82,9 +82,10 @@ def test_write_refs_multiple():
     assert os.path.isfile('ethane-multi.bib')
     with open(get_fn('ethane-multi.bib')) as file1:
         with open('ethane-multi.bib') as file2:
-            diff = difflib.ndiff(file1.readlines(), file2.readlines())
-    changes = [l for l in diff if l.startswith('+ ') or l.startswith('- ')]
-    assert not changes
+            diff = list(difflib.unified_diff(file1.readlines(),
+                                             file2.readlines(),
+                                             n=0))
+    assert not diff
 
 def test_preserve_resname():
     untyped_ethane = pmd.load_file(get_fn('ethane.mol2'), structure=True)

--- a/foyer/tests/test_forcefield.py
+++ b/foyer/tests/test_forcefield.py
@@ -1,3 +1,4 @@
+import difflib
 import glob
 import os
 from pkg_resources import resource_filename
@@ -73,6 +74,17 @@ def test_write_refs():
     oplsaa = Forcefield(name='oplsaa')
     ethane = oplsaa.apply(mol2, references_file='ethane.bib')
     assert os.path.isfile('ethane.bib')
+
+def test_write_refs_multiple():
+    mol2 = mb.load(get_fn('ethane.mol2'))
+    oplsaa = Forcefield(forcefield_files=get_fn('refs-multi.xml'))
+    ethane = oplsaa.apply(mol2, references_file='ethane-multi.bib')
+    assert os.path.isfile('ethane-multi.bib')
+    with open(get_fn('ethane-multi.bib')) as file1:
+        with open('ethane-multi.bib') as file2:
+            diff = difflib.ndiff(file1.readlines(), file2.readlines())
+        changes = [l for l in diff if l.startswith('+ ') or l.startswith('- ')]
+        assert not changes
 
 def test_preserve_resname():
     untyped_ethane = pmd.load_file(get_fn('ethane.mol2'), structure=True)

--- a/foyer/tests/test_forcefield.py
+++ b/foyer/tests/test_forcefield.py
@@ -83,8 +83,8 @@ def test_write_refs_multiple():
     with open(get_fn('ethane-multi.bib')) as file1:
         with open('ethane-multi.bib') as file2:
             diff = difflib.ndiff(file1.readlines(), file2.readlines())
-        changes = [l for l in diff if l.startswith('+ ') or l.startswith('- ')]
-        assert not changes
+    changes = [l for l in diff if l.startswith('+ ') or l.startswith('- ')]
+    assert not changes
 
 def test_preserve_resname():
     untyped_ethane = pmd.load_file(get_fn('ethane.mol2'), structure=True)


### PR DESCRIPTION
Currently the `doi` attribute for atomtypes defined in a force field XML file only supports a single DOI. However, there may be instances where multiple DOIs would be appropriate (see #158). This PR adds support for listing multiple DOIs within the `doi` attribute, and passes this information through to the BibTeX file that is created.