### PR TITLE
Add support for overrides definitions with spaces

### DIFF
--- a/foyer/forcefield.py
+++ b/foyer/forcefield.py
@@ -329,7 +329,8 @@ class Forcefield(app.ForceField):
         if 'def' in parameters:
             self.atomTypeDefinitions[name] = parameters['def']
         if 'overrides' in parameters:
-            overrides = set(parameters['overrides'].split(","))
+            overrides = set(atype.strip() for atype
+                            in parameters['overrides'].split(","))
             if overrides:
                 self.atomTypeOverrides[name] = overrides
         if 'des' in parameters:

--- a/foyer/tests/files/overrides-space.xml
+++ b/foyer/tests/files/overrides-space.xml
@@ -1,0 +1,23 @@
+<ForceField>
+ <AtomTypes>
+  <Type name="CT" class="CT" element="C" mass="12.01100" def="C"/>
+  <Type name="CT2" class="CT" element="C" mass="12.01100" def="C(H)(H)(H)"
+        overrides="CT"/>
+  <Type name="HC" class="HC" element="H" mass="1.0081" def="H"/>
+  <Type name="CT3" class="CT" element="C" mass="12.01100" def="C(H)(H)(H)C"
+        overrides="CT, CT2"/>
+ </AtomTypes>
+ <HarmonicBondForce>
+  <Bond class1="CT" class2="HC" length="0.163" k="251040.0"/>
+  <Bond class1="CT" class2="CT" length="0.163" k="251040.0"/>
+ </HarmonicBondForce>
+ <HarmonicAngleForce>
+  <Angle class1="CT" class2="CT" class3="HC" angle="2.7053" k="397.48"/>
+  <Angle class1="HC" class2="CT" class3="HC" angle="2.7053" k="397.48"/>
+  <Angle class1="CT" class2="CT" class3="CT" angle="1.9111" k="397.48"/>
+ </HarmonicAngleForce>
+ <PeriodicTorsionForce>
+     <Proper class1="CT" class2="CT" class3="CT" class4="HC" periodicity1="1" phase1="3.14" k1="3.1"/>
+     <Proper class1="HC" class2="CT" class3="CT" class4="HC" periodicity1="1" phase1="3.14" k1="3.1"/>
+ </PeriodicTorsionForce>
+</ForceField>

--- a/foyer/tests/test_forcefield.py
+++ b/foyer/tests/test_forcefield.py
@@ -187,3 +187,9 @@ def test_missing_topo_params(ff_filename, kwargs):
         ethane = oplsaa_with_typo.apply(ethane)
     with pytest.warns(UserWarning):
         ethane = oplsaa_with_typo.apply(ethane, **kwargs)
+
+def test_overrides_space():
+    ethane = mb.load(get_fn('ethane.mol2'))
+    ff = Forcefield(forcefield_files=get_fn('overrides-space.xml'))
+    typed_ethane = ff.apply(ethane)
+    assert typed_ethane.atoms[0].type == 'CT3'


### PR DESCRIPTION
Currently multiple atomtype names can be listed within a single `overrides` attribute for an atomtype definition in a force field XML file, but these must be separated by a comma only and no space, e.g. `overrides="opls_1,opls_2"`.

This PR updates this behavior to allow for spaces between atomtype names, e.g. `overrides="opls_1, opls_2"`.