### PR TITLE
Ignore VSCode project and setup files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,10 @@
 # C extensions
 *.so
 
+# VSCode
+.vscode
+.vscode/*
+
 # Packages
 *.egg
 *.egg-info


### PR DESCRIPTION
Using Microsoft's VSCode generates an addtional directory
and files to assist the various plugins, save states, etc.

This is not needed for other users.

This has been added to the .gitignore file to prevent these files from
being committed erroneously.