### PR TITLE
Support Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ install:
   - conda config --add channels omnia
   - conda config --add channels conda-forge
   - conda config --add channels mosdef
+  - conda config --add channels mwt 
   - conda create -n test-environment python=$PYTHON_VERSION --file requirements.txt
   - source activate test-environment
   - pip install -e .

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,10 @@ install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install md5sha1sum; fi
   - source devtools/travis-ci/install_conda.sh
   - conda config --set always_yes yes --set changeps1 no
+  - conda config --add channels mwt
   - conda config --add channels omnia
   - conda config --add channels conda-forge
   - conda config --add channels mosdef
-  - conda config --add channels mwt 
   - conda create -n test-environment python=$PYTHON_VERSION --file requirements.txt
   - source activate test-environment
   - pip install -e .

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,10 @@ matrix:
   include:
     - { os: linux, env: PYTHON_VERSION=2.7 }
     - { os: linux, env: PYTHON_VERSION=3.5 }
+    - { os: linux, env: PYTHON_VERSION=3.6 }
     - { os: osx, env: PYTHON_VERSION=2.7 }
     - { os: osx, env: PYTHON_VERSION=3.5 }
+    - { os: osx, env: PYTHON_VERSION=3.6 }
 
 env:
   global:


### PR DESCRIPTION
Python 3.6 has been around for a while - and even Python 3.7 isn't too new - so we should start trying to support it.

This will probably require https://github.com/mosdef-hub/mbuild/pull/457 and https://github.com/mosdef-hub/mbuild/pull/435 to be merged first and then an mbuild release.

I am temporarily getting around plyplus issues (#172) by hosting builds on my own Anaconda channel; I will move those to the mosdef channel if it becomes necessary.