### PR TITLE
Drop Python 2.7 testing from Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,9 +8,6 @@ environment:
 
   matrix:
     - PYTHON: "C:\\Miniconda36-x64"
-      CONDA_PY: "27"
-      ARCH: "64"
-    - PYTHON: "C:\\Miniconda36-x64"
       CONDA_PY: "35"
       ARCH: "64"
     - PYTHON: "C:\\Miniconda36-x64"


### PR DESCRIPTION
It's starting to give me problems (see the mess of #228) so I think it's time to just drop it. Note that the Python 3 builds on Appveyor and Python 2.7 builds on Travis have been passing.

Arguably this is an opportunity to drop it from Travis too, but I would prefer keeping it along until it gives us non-trivial-to-fix problems.