### PR TITLE
Use built-in sets for whitelists & blacklists

### DIFF
--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -18,7 +18,6 @@ requirements:
     - python
     - parmed
     - networkx >=2.0
-    - boltons
     - six
     - openmm <7.3
     - plyplus

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -18,7 +18,7 @@ requirements:
     - python
     - parmed
     - networkx >=2.0
-    - oset
+    - boltons
     - six
     - openmm <7.3
     - plyplus

--- a/foyer/smarts_graph.py
+++ b/foyer/smarts_graph.py
@@ -4,7 +4,6 @@ import sys
 
 import networkx as nx
 from networkx.algorithms import isomorphism
-from boltons.setutils import IndexedSet
 import parmed.periodic_table as pt
 
 from foyer.smarts import SMARTS
@@ -313,8 +312,8 @@ def _prepare_atoms(topology, compute_cycles=False):
             if compute_cycles:
                 atom.cycles = set()
             if not has_whitelists:
-                atom.whitelist = IndexedSet()
-                atom.blacklist = IndexedSet()
+                atom.whitelist = set()
+                atom.blacklist = set()
 
     if compute_cycles:
         bond_graph = nx.Graph()

--- a/foyer/smarts_graph.py
+++ b/foyer/smarts_graph.py
@@ -4,7 +4,7 @@ import sys
 
 import networkx as nx
 from networkx.algorithms import isomorphism
-from oset import oset as OrderedSet
+from boltons.setutils import IndexedSet
 import parmed.periodic_table as pt
 
 from foyer.smarts import SMARTS
@@ -313,8 +313,8 @@ def _prepare_atoms(topology, compute_cycles=False):
             if compute_cycles:
                 atom.cycles = set()
             if not has_whitelists:
-                atom.whitelist = OrderedSet()
-                atom.blacklist = OrderedSet()
+                atom.whitelist = IndexedSet()
+                atom.blacklist = IndexedSet()
 
     if compute_cycles:
         bond_graph = nx.Graph()

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-oset
+boltons
 openmm < 7.3
 mbuild
 parmed

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,3 @@
-boltons
 openmm < 7.3
 mbuild
 parmed

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-boltons
 openmm < 7.3
 parmed
 networkx >=2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-oset
+boltons
 openmm < 7.3
 parmed
 networkx >=2.0


### PR DESCRIPTION
See #226 for discussion and #205 for context. `boltons` seems to be a light dep but there doesn't seem to be a compelling reason to need order/indexing/etc in the whitelist blacklist. Maybe it could help in debugging but that part of the package seems pretty stable now.

Probably squash & merge this one, or I can clean up the git history.