### PR TITLE
Switch conda recipe to noarch

### DIFF
--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -6,6 +6,7 @@ source:
   path: ../../
 
 build:
+  noarch: python
   number: {{ environ.get('GIT_DESCRIBE_NUMBER', 0)}}
   script: python setup.py install --single-version-externally-managed --record record.txt
 


### PR DESCRIPTION
We previously switched mbuild over and it seems to be working fine.

Advantages:

* we don't need to do `conda convert` when building packages for anaconda
* a user on a version of Python we don't explicitly support, i.e. Python 3.7, could try to install it with less work than building from source

h/t @mikemhenry 