### PR TITLE
Periodictorsions xml

### DIFF
--- a/foyer/tests/files/oplsaa-periodic.xml
+++ b/foyer/tests/files/oplsaa-periodic.xml
@@ -1,10 +1,10 @@
 <ForceField>
   <!-- Not a valid FF, just one that has periodic diehdrals for testing -->
   <AtomTypes>
-    <Type name="opls_135" class="CT" element="C" mass="12.01078" def="[C;X4](C)(H)(H)H" desc="" doi="{'10.1021/ja9621760'}"/>
-    <Type name="opls_140" class="HC" element="H" mass="1.007947" def="H[C;X4]" desc="" doi="{'10.1021/ja9621760'}"/>
-    <Type name="opls_145" class="CA" element="C" mass="12.01078" def="[C;X3;r6]1[C;X3;r6][C;X3;r6][C;X3;r6][C;X3;r6][C;X3;r6]1" desc="" doi="{'10.1021/ja9621760'}"/>
-    <Type name="opls_146" class="HA" element="H" mass="1.007947" def="[H][C;%opls_145]" desc="" doi="{'10.1021/ja9621760'}"/>
+    <Type name="opls_135" class="CT" element="C" mass="12.01078" def="[C;X4](C)(H)(H)H" desc="" doi="10.1021/ja9621760"/>
+    <Type name="opls_140" class="HC" element="H" mass="1.007947" def="H[C;X4]" desc="" doi="10.1021/ja9621760"/>
+    <Type name="opls_145" class="CA" element="C" mass="12.01078" def="[C;X3;r6]1[C;X3;r6][C;X3;r6][C;X3;r6][C;X3;r6][C;X3;r6]1" desc="" doi="10.1021/ja9621760"/>
+    <Type name="opls_146" class="HA" element="H" mass="1.007947" def="[H][C;%opls_145]" desc="" doi="10.1021/ja9621760"/>
   </AtomTypes>
   <NonbondedForce coulomb14scale="0.5" lj14scale="0.5">
     <Atom type="opls_135" charge="-0.18" sigma="3.5" epsilon="0.276144"/>

--- a/foyer/tests/files/oplsaa_multiperiodicitytorsion.xml
+++ b/foyer/tests/files/oplsaa_multiperiodicitytorsion.xml
@@ -1,0 +1,33 @@
+<ForceField>
+  <!-- Not a valid FF, just one that has periodic diehdrals for testing -->
+  <AtomTypes>
+    <Type name="opls_135" class="CT" element="C" mass="12.01078" def="[C;X4](C)(H)(H)H" desc="" doi="10.1021/ja9621760"/>
+    <Type name="opls_140" class="HC" element="H" mass="1.007947" def="H[C;X4]" desc="" doi="10.1021/ja9621760"/>
+    <Type name="opls_145" class="CA" element="C" mass="12.01078" def="[C;X3;r6]1[C;X3;r6][C;X3;r6][C;X3;r6][C;X3;r6][C;X3;r6]1" desc="" doi="10.1021/ja9621760"/>
+    <Type name="opls_146" class="HA" element="H" mass="1.007947" def="[H][C;%opls_145]" desc="" doi="10.1021/ja9621760"/>
+  </AtomTypes>
+  <NonbondedForce coulomb14scale="0.5" lj14scale="0.5">
+    <Atom type="opls_135" charge="-0.18" sigma="3.5" epsilon="0.276144"/>
+    <Atom type="opls_140" charge="0.06" sigma="2.5" epsilon="0.12552"/>
+    <Atom type="opls_145" charge="-0.115" sigma="3.55" epsilon="0.29288"/>
+    <Atom type="opls_146" charge="0.115" sigma="2.42" epsilon="0.12552"/>
+  </NonbondedForce>
+  <HarmonicBondForce>
+    <Bond type1="opls_135" type2="opls_135" length="0.1529" k="224262.4"/>
+    <Bond type1="opls_135" type2="opls_140" length="0.109" k="284512.0"/>
+    <Bond type1="opls_145" type2="opls_145" length="0.14" k="392459.2"/>
+    <Bond type1="opls_145" type2="opls_146" length="0.108" k="307105.6"/>
+  </HarmonicBondForce>
+  <HarmonicAngleForce>
+    <Angle type1="opls_135" type2="opls_135" type3="opls_140" angle="1.932079482" k="313.8"/>
+    <Angle type1="opls_140" type2="opls_135" type3="opls_140" angle="1.8814649337" k="276.144"/>
+    <Angle type1="opls_145" type2="opls_145" type3="opls_145" angle="2.0943951024" k="527.184"/>
+    <Angle type1="opls_145" type2="opls_145" type3="opls_146" angle="2.0943951024" k="292.88"/>
+  </HarmonicAngleForce>
+  <PeriodicTorsionForce>
+    <Proper type1="opls_140" type2="opls_135" type3="opls_135" type4="opls_140" periodicity1="1" phase1="3.14" k1="3.1" periodicity2="4" phase2="1.57" k2="100" periodicity3="3" phase3="1.00" k3="400"/>
+    <Proper type1="opls_145" type2="opls_145" type3="opls_145" type4="opls_145" periodicity1="1" phase1="3.14" k1="3.1" periodicity2="3" phase2="3.14" k2="350"/>
+    <Proper type1="opls_145" type2="opls_145" type3="opls_145" type4="opls_146" periodicity1="1" phase1="3.14" k1="3.1" periodicity2="3" phase2="3.14" k2="350"/>
+    <Proper type1="opls_146" type2="opls_145" type3="opls_145" type4="opls_146" periodicity1="1" phase1="3.14" k1="3.1" periodicity2="3" phase2="3.14" k2="350"/>
+  </PeriodicTorsionForce>
+</ForceField>

--- a/foyer/tests/test_forcefield.py
+++ b/foyer/tests/test_forcefield.py
@@ -295,3 +295,10 @@ def test_write_xml_multiple_periodictorsions(filename):
     typed_struc = ff.apply(cmpd, assert_dihedral_params=False)
     typed_struc.write_foyer(filename='multi-periodictorsions.xml', forcefield=ff, unique=True)
 
+    partial_ff = Forcefield(forcefield_files='multi-periodictorsions.xml')
+    typed_by_partial = partial_ff.apply(cmpd, assert_dihedral_params=False)
+
+    assert len(typed_struc.bonds) == len(typed_by_partial.bonds)
+    assert len(typed_struc.angles) == len(typed_by_partial.angles)
+    assert len(typed_struc.dihedrals) == len(typed_by_partial.dihedrals)
+

--- a/foyer/tests/test_forcefield.py
+++ b/foyer/tests/test_forcefield.py
@@ -287,3 +287,11 @@ def test_write_xml(filename):
 
     assert sigma_factor_pre == sigma_factor_post
     assert epsilon_factor_pre == epsilon_factor_post
+
+@pytest.mark.parametrize("filename", ['ethane.mol2', 'benzene.mol2'])
+def test_write_xml_multiple_periodictorsions(filename):
+    cmpd = pmd.load_file(get_fn(filename), structure=True)
+    ff = Forcefield(forcefield_files=get_fn('oplsaa_multiperiodicitytorsion.xml'))
+    typed_struc = ff.apply(cmpd, assert_dihedral_params=False)
+    typed_struc.write_foyer(filename='multi-periodictorsions.xml', forcefield=ff, unique=True)
+

--- a/foyer/tests/test_forcefield.py
+++ b/foyer/tests/test_forcefield.py
@@ -3,6 +3,8 @@ import glob
 import os
 from pkg_resources import resource_filename
 
+from lxml import etree as ET
+
 import mbuild as mb
 from mbuild.examples import Alkane
 import parmed as pmd
@@ -301,4 +303,10 @@ def test_write_xml_multiple_periodictorsions(filename):
     assert len(typed_struc.bonds) == len(typed_by_partial.bonds)
     assert len(typed_struc.angles) == len(typed_by_partial.angles)
     assert len(typed_struc.dihedrals) == len(typed_by_partial.dihedrals)
+
+    root = ET.parse('multi-periodictorsions.xml')
+    periodic_element = root.find('PeriodicTorsionForce')
+    assert 'periodicity2' in periodic_element[0].attrib
+    assert 'k2' in periodic_element[0].attrib
+    assert 'phase2' in periodic_element[0].attrib
 


### PR DESCRIPTION
### PR Summary:
#239 This code modifies the XML writer to look for multiple periodictorsionforces that apply to the same dihedrals. This is done by comparing the "current" periodic dihedral to the "previous" periodic dihedral, and determining whether the two dihedral forces should be merged into one. 

As a side note, the issues with the DOI XMLprinting should have been appropriately addressed in #161, any issues we saw with the DOI XMLprinting were due to flaws in the "source" FFXML we were using to parametrize these structures, not in how we were printing to the "sink" FFXML

### PR Checklist
------------
 - [x] Includes appropriate unit test(s)
 - [x] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [x] Issue(s) raised/addressed?
