### PR TITLE
Move tests into classes so they can inherit pytest fixtures

### DIFF
--- a/foyer/tests/base_test.py
+++ b/foyer/tests/base_test.py
@@ -1,0 +1,8 @@
+import pytest
+
+
+class BaseTest:
+
+    @pytest.fixture(autouse=True)
+    def initdir(self, tmpdir):
+        tmpdir.chdir()

--- a/foyer/tests/test_atomtyping.py
+++ b/foyer/tests/test_atomtyping.py
@@ -7,23 +7,25 @@ import pytest
 from foyer import Forcefield
 from foyer.exceptions import FoyerError
 from foyer.tests.utils import get_fn
+from foyer.tests.base_test import BaseTest
 
 OPLS_TESTFILES_DIR = resource_filename('foyer', 'opls_validation')
 
 
-def test_missing_overrides():
-    top = os.path.join(OPLS_TESTFILES_DIR, 'benzene/benzene.top')
-    gro = os.path.join(OPLS_TESTFILES_DIR, 'benzene/benzene.gro')
-    structure = pmd.load_file(top, xyz=gro)
-
-    forcefield = Forcefield(get_fn('missing_overrides.xml'))
-    with pytest.raises(FoyerError):
-        forcefield.apply(structure)
-
-
-def test_missing_definition():
-    structure = pmd.load_file(get_fn('silly_chemistry.mol2'), structure=True)
-
-    forcefield = Forcefield(get_fn('missing_overrides.xml'))
-    with pytest.raises(FoyerError):
-        forcefield.apply(structure)
+class TestAtomTyping(BaseTest):
+    def test_missing_overrides(self):
+        top = os.path.join(OPLS_TESTFILES_DIR, 'benzene/benzene.top')
+        gro = os.path.join(OPLS_TESTFILES_DIR, 'benzene/benzene.gro')
+        structure = pmd.load_file(top, xyz=gro)
+    
+        forcefield = Forcefield(get_fn('missing_overrides.xml'))
+        with pytest.raises(FoyerError):
+            forcefield.apply(structure)
+    
+    
+    def test_missing_definition(self):
+        structure = pmd.load_file(get_fn('silly_chemistry.mol2'), structure=True)
+    
+        forcefield = Forcefield(get_fn('missing_overrides.xml'))
+        with pytest.raises(FoyerError):
+            forcefield.apply(structure)

--- a/foyer/tests/test_forcefield.py
+++ b/foyer/tests/test_forcefield.py
@@ -14,276 +14,278 @@ from foyer.forcefield import _check_independent_residues
 from foyer.exceptions import FoyerError
 from foyer.tests.utils import get_fn
 from foyer.utils.io import has_mbuild
+from foyer.tests.base_test import BaseTest
 
 
 FF_DIR = resource_filename('foyer', 'forcefields')
 FORCEFIELDS = glob.glob(os.path.join(FF_DIR, '*.xml'))
 
 
-def test_load_files():
-    for ff_file in FORCEFIELDS:
-        ff1 = Forcefield(forcefield_files=ff_file)
-        assert len(ff1._atomTypes) > 0
-
-        ff2 = Forcefield(forcefield_files=ff_file)
-        assert len(ff1._atomTypes) == len(ff2._atomTypes)
-
-
-def test_duplicate_type_definitions():
-    with pytest.raises(ValueError):
-        ff4 = Forcefield(name='oplsaa', forcefield_files=FORCEFIELDS)
-
-
-def test_missing_type_definitions():
-    with pytest.raises(FoyerError):
-        FF = Forcefield()
+class TestForcefield(BaseTest):
+    def test_load_files(self):
+        for ff_file in FORCEFIELDS:
+            ff1 = Forcefield(forcefield_files=ff_file)
+            assert len(ff1._atomTypes) > 0
+    
+            ff2 = Forcefield(forcefield_files=ff_file)
+            assert len(ff1._atomTypes) == len(ff2._atomTypes)
+    
+    
+    def test_duplicate_type_definitions(self):
+        with pytest.raises(ValueError):
+            ff4 = Forcefield(name='oplsaa', forcefield_files=FORCEFIELDS)
+    
+    
+    def test_missing_type_definitions(self):
+        with pytest.raises(FoyerError):
+            FF = Forcefield()
+            ethane = pmd.load_file(get_fn('ethane.mol2'), structure=True)
+            FF.apply(ethane)
+    
+    def test_from_parmed(self):
+        mol2 = pmd.load_file(get_fn('ethane.mol2'), structure=True)
+        oplsaa = Forcefield(name='oplsaa')
+        ethane = oplsaa.apply(mol2)
+    
+        assert sum((1 for at in ethane.atoms if at.type == 'opls_135')) == 2
+        assert sum((1 for at in ethane.atoms if at.type == 'opls_140')) == 6
+        assert len(ethane.bonds) == 7
+        assert all(x.type for x in ethane.bonds)
+        assert len(ethane.angles) == 12
+        assert all(x.type for x in ethane.angles)
+        assert len(ethane.rb_torsions) == 9
+        assert all(x.type for x in ethane.dihedrals)
+    
+        mol2 = pmd.load_file(get_fn('ethane.mol2'), structure=True)
+        mol2.box_vectors = [[2, 0, 0], [0, 2, 0], [0, 0, 2]]
+        oplsaa = Forcefield(name='oplsaa')
+        ethane = oplsaa.apply(mol2)
+    
+        assert ethane.box_vectors == mol2.box_vectors
+    
+    @pytest.mark.skipif(not has_mbuild, reason="mbuild is not installed")
+    def test_from_mbuild(self):
+        mol2 = mb.load(get_fn('ethane.mol2'))
+        oplsaa = Forcefield(name='oplsaa')
+        ethane = oplsaa.apply(mol2)
+    
+        assert sum((1 for at in ethane.atoms if at.type == 'opls_135')) == 2
+        assert sum((1 for at in ethane.atoms if at.type == 'opls_140')) == 6
+        assert len(ethane.bonds) == 7
+        assert all(x.type for x in ethane.bonds)
+        assert len(ethane.angles) == 12
+        assert all(x.type for x in ethane.angles)
+        assert len(ethane.rb_torsions) == 9
+        assert all(x.type for x in ethane.dihedrals)
+    
+    @pytest.mark.skipif(not has_mbuild, reason="mbuild is not installed")
+    def test_write_refs(self):
+        mol2 = mb.load(get_fn('ethane.mol2'))
+        oplsaa = Forcefield(name='oplsaa')
+        ethane = oplsaa.apply(mol2, references_file='ethane.bib')
+        assert os.path.isfile('ethane.bib')
+    
+    @pytest.mark.skipif(not has_mbuild, reason="mbuild is not installed")
+    def test_write_refs_multiple(self):
+        mol2 = mb.load(get_fn('ethane.mol2'))
+        oplsaa = Forcefield(forcefield_files=get_fn('refs-multi.xml'))
+        ethane = oplsaa.apply(mol2, references_file='ethane-multi.bib')
+        assert os.path.isfile('ethane-multi.bib')
+        with open(get_fn('ethane-multi.bib')) as file1:
+            with open('ethane-multi.bib') as file2:
+                diff = list(difflib.unified_diff(file1.readlines(),
+                                                 file2.readlines(),
+                                                 n=0))
+        assert not diff
+    
+    def test_preserve_resname(self):
+        untyped_ethane = pmd.load_file(get_fn('ethane.mol2'), structure=True)
+        untyped_resname = untyped_ethane.residues[0].name
+        oplsaa = Forcefield(name='oplsaa')
+        typed_ethane = oplsaa.apply(untyped_ethane)
+        typed_resname = typed_ethane.residues[0].name
+        assert typed_resname == untyped_resname
+    
+    @pytest.mark.skipif(not has_mbuild, reason="mbuild is not installed")
+    def test_apply_residues(self):
+        from mbuild.examples import Ethane
+        ethane = Ethane()
+        opls = Forcefield(name='oplsaa')
+        typed = opls.apply(ethane, residues='CH3')
+        assert len([res for res in typed.residues if res.name == 'CH3']) == 2
+    
+    @pytest.mark.skipif(not has_mbuild, reason="mbuild is not installed")
+    def test_from_mbuild_customtype(self):
+        mol2 = mb.load(get_fn('ethane_customtype.pdb'))
+        customtype_ff = Forcefield(forcefield_files=get_fn('validate_customtypes.xml'))
+        ethane = customtype_ff.apply(mol2)
+    
+        assert sum((1 for at in ethane.atoms if at.type == 'C3')) == 2
+        assert sum((1 for at in ethane.atoms if at.type == 'Hb')) == 6
+        assert len(ethane.bonds) == 7
+        assert all(x.type for x in ethane.bonds)
+        assert len(ethane.angles) == 12
+        assert all(x.type for x in ethane.angles)
+        assert len(ethane.rb_torsions) == 9
+        assert all(x.type for x in ethane.dihedrals)
+    
+    def test_improper_dihedral(self):
+        untyped_benzene = pmd.load_file(get_fn('benzene.mol2'), structure=True)
+        ff_improper = Forcefield(forcefield_files=get_fn('improper_dihedral.xml'))
+        benzene = ff_improper.apply(untyped_benzene, assert_dihedral_params=False)
+        assert len(benzene.dihedrals) == 18
+        assert len([dih for dih in benzene.dihedrals if dih.improper]) == 6
+        assert len([dih for dih in benzene.dihedrals if not dih.improper]) == 12
+    
+    def test_residue_map(self):
         ethane = pmd.load_file(get_fn('ethane.mol2'), structure=True)
-        FF.apply(ethane)
-
-def test_from_parmed():
-    mol2 = pmd.load_file(get_fn('ethane.mol2'), structure=True)
-    oplsaa = Forcefield(name='oplsaa')
-    ethane = oplsaa.apply(mol2)
-
-    assert sum((1 for at in ethane.atoms if at.type == 'opls_135')) == 2
-    assert sum((1 for at in ethane.atoms if at.type == 'opls_140')) == 6
-    assert len(ethane.bonds) == 7
-    assert all(x.type for x in ethane.bonds)
-    assert len(ethane.angles) == 12
-    assert all(x.type for x in ethane.angles)
-    assert len(ethane.rb_torsions) == 9
-    assert all(x.type for x in ethane.dihedrals)
-
-    mol2 = pmd.load_file(get_fn('ethane.mol2'), structure=True)
-    mol2.box_vectors = [[2, 0, 0], [0, 2, 0], [0, 0, 2]]
-    oplsaa = Forcefield(name='oplsaa')
-    ethane = oplsaa.apply(mol2)
-
-    assert ethane.box_vectors == mol2.box_vectors
-
-@pytest.mark.skipif(not has_mbuild, reason="mbuild is not installed")
-def test_from_mbuild():
-    mol2 = mb.load(get_fn('ethane.mol2'))
-    oplsaa = Forcefield(name='oplsaa')
-    ethane = oplsaa.apply(mol2)
-
-    assert sum((1 for at in ethane.atoms if at.type == 'opls_135')) == 2
-    assert sum((1 for at in ethane.atoms if at.type == 'opls_140')) == 6
-    assert len(ethane.bonds) == 7
-    assert all(x.type for x in ethane.bonds)
-    assert len(ethane.angles) == 12
-    assert all(x.type for x in ethane.angles)
-    assert len(ethane.rb_torsions) == 9
-    assert all(x.type for x in ethane.dihedrals)
-
-@pytest.mark.skipif(not has_mbuild, reason="mbuild is not installed")
-def test_write_refs():
-    mol2 = mb.load(get_fn('ethane.mol2'))
-    oplsaa = Forcefield(name='oplsaa')
-    ethane = oplsaa.apply(mol2, references_file='ethane.bib')
-    assert os.path.isfile('ethane.bib')
-
-@pytest.mark.skipif(not has_mbuild, reason="mbuild is not installed")
-def test_write_refs_multiple():
-    mol2 = mb.load(get_fn('ethane.mol2'))
-    oplsaa = Forcefield(forcefield_files=get_fn('refs-multi.xml'))
-    ethane = oplsaa.apply(mol2, references_file='ethane-multi.bib')
-    assert os.path.isfile('ethane-multi.bib')
-    with open(get_fn('ethane-multi.bib')) as file1:
-        with open('ethane-multi.bib') as file2:
-            diff = list(difflib.unified_diff(file1.readlines(),
-                                             file2.readlines(),
-                                             n=0))
-    assert not diff
-
-def test_preserve_resname():
-    untyped_ethane = pmd.load_file(get_fn('ethane.mol2'), structure=True)
-    untyped_resname = untyped_ethane.residues[0].name
-    oplsaa = Forcefield(name='oplsaa')
-    typed_ethane = oplsaa.apply(untyped_ethane)
-    typed_resname = typed_ethane.residues[0].name
-    assert typed_resname == untyped_resname
-
-@pytest.mark.skipif(not has_mbuild, reason="mbuild is not installed")
-def test_apply_residues():
-    from mbuild.examples import Ethane
-    ethane = Ethane()
-    opls = Forcefield(name='oplsaa')
-    typed = opls.apply(ethane, residues='CH3')
-    assert len([res for res in typed.residues if res.name == 'CH3']) == 2
-
-@pytest.mark.skipif(not has_mbuild, reason="mbuild is not installed")
-def test_from_mbuild_customtype():
-    mol2 = mb.load(get_fn('ethane_customtype.pdb'))
-    customtype_ff = Forcefield(forcefield_files=get_fn('validate_customtypes.xml'))
-    ethane = customtype_ff.apply(mol2)
-
-    assert sum((1 for at in ethane.atoms if at.type == 'C3')) == 2
-    assert sum((1 for at in ethane.atoms if at.type == 'Hb')) == 6
-    assert len(ethane.bonds) == 7
-    assert all(x.type for x in ethane.bonds)
-    assert len(ethane.angles) == 12
-    assert all(x.type for x in ethane.angles)
-    assert len(ethane.rb_torsions) == 9
-    assert all(x.type for x in ethane.dihedrals)
-
-def test_improper_dihedral():
-    untyped_benzene = pmd.load_file(get_fn('benzene.mol2'), structure=True)
-    ff_improper = Forcefield(forcefield_files=get_fn('improper_dihedral.xml'))
-    benzene = ff_improper.apply(untyped_benzene, assert_dihedral_params=False)
-    assert len(benzene.dihedrals) == 18
-    assert len([dih for dih in benzene.dihedrals if dih.improper]) == 6
-    assert len([dih for dih in benzene.dihedrals if not dih.improper]) == 12
-
-def test_residue_map():
-    ethane = pmd.load_file(get_fn('ethane.mol2'), structure=True)
-    ethane *= 2
-    oplsaa = Forcefield(name='oplsaa')
-    topo, NULL = generate_topology(ethane)
-    topo_with = oplsaa.run_atomtyping(topo, use_residue_map=True)
-    topo_without = oplsaa.run_atomtyping(topo, use_residue_map=False)
-    assert all([a.id for a in topo_with.atoms()][0])
-    assert all([a.id for a in topo_without.atoms()][0])
-    struct_with = pmd.openmm.load_topology(topo_with, oplsaa.createSystem(topo_with))
-    struct_without = pmd.openmm.load_topology(topo_without, oplsaa.createSystem(topo_without))
-    for atom_with, atom_without in zip(struct_with.atoms, struct_without.atoms):
-        assert atom_with.type == atom_without.type
-        b_with = atom_with.bond_partners
-        b_without = atom_without.bond_partners
-        assert [a0.type for a0 in b_with] == [a1.type for a1 in b_without]
-        assert [a0.idx for a0 in b_with] == [a1.idx for a1 in b_without]
-
-def test_independent_residues_molecules():
-    """Test to see that _check_independent_residues works for molecules."""
-    butane = Alkane(4)
-    structure = butane.to_parmed()
-    topo, NULL = generate_topology(structure)
-    assert _check_independent_residues(topo)
-    structure = butane.to_parmed(residues=['RES', 'CH3'])
-    topo, NULL = generate_topology(structure)
-    assert not _check_independent_residues(topo)
-
-@pytest.mark.skipif(not has_mbuild, reason="mbuild is not installed")
-def test_independent_residues_atoms():
-    """Test to see that _check_independent_residues works for single aotms."""
-    argon = mb.Compound()
-    argon.name = 'Ar'
-    structure = argon.to_parmed()
-    topo, NULL = generate_topology(structure)
-    assert _check_independent_residues(topo)
-
-@pytest.mark.skipif(not has_mbuild, reason="mbuild is not installed")
-def test_topology_precedence():
-    """Test to see if topology precedence is properly adhered to.
-
-    This test uses a force field file where bond, angle, and dihedral
-    parameters are present with different counts of `type` definitions.
-    It checks that:
-        1. The parameters with the higher number of `type` definitions
-           are assigned (because they are given the highest precedence)
-        2. That if multiple definitions exist with the same number of
-           `type` definitions, that the convention from OpenMM is followed
-           whereby the definitions that occurs earliest in the XML is
-           assigned.
-    """
-    ethane = mb.load(get_fn('ethane.mol2'))
-    ff = Forcefield(forcefield_files=get_fn('ethane-topo-precedence.xml'))
-    typed_ethane = ff.apply(ethane)
-
-    assert len([bond for bond in typed_ethane.bonds
-                if round(bond.type.req, 2) == 1.15]) == 6
-    assert len([bond for bond in typed_ethane.bonds
-                if round(bond.type.req, 2) == 1.6]) == 1
-    assert len([angle for angle in typed_ethane.angles
-                if round(angle.type.theteq, 3) == 120.321]) == 6
-    assert len([angle for angle in typed_ethane.angles
-                if round(angle.type.theteq, 3) == 97.403]) == 6
-    assert len([rb for rb in typed_ethane.rb_torsions
-                if round(rb.type.c0, 3) == 0.287]) == 9
-
-@pytest.mark.skipif(not has_mbuild, reason="mbuild is not installed")
-@pytest.mark.parametrize("ff_filename,kwargs", [
-    ("ethane-angle-typo.xml", {"assert_angle_params": False}),
-    ("ethane-dihedral-typo.xml", {"assert_dihedral_params": False})
-])
-def test_missing_topo_params(ff_filename, kwargs):
-    """Test that the user is notified if not all topology parameters are found."""
-    ethane = mb.load(get_fn('ethane.mol2'))
-    oplsaa_with_typo = Forcefield(forcefield_files=get_fn(ff_filename))
-    with pytest.raises(Exception):
-        ethane = oplsaa_with_typo.apply(ethane)
-    with pytest.warns(UserWarning):
-        ethane = oplsaa_with_typo.apply(ethane, **kwargs)
-
-@pytest.mark.skipif(not has_mbuild, reason="mbuild is not installed")
-def test_overrides_space():
-    ethane = mb.load(get_fn('ethane.mol2'))
-    ff = Forcefield(forcefield_files=get_fn('overrides-space.xml'))
-    typed_ethane = ff.apply(ethane)
-    assert typed_ethane.atoms[0].type == 'CT3'
-
-def test_assert_bonds():
-    ff = Forcefield(name='trappe-ua')
-
-    derponium = mb.Compound()
-    at1 = mb.Particle(name='H')
-    at2 = mb.Particle(name='O')
-    at3 = mb.Particle(name='_CH4')
-
-    derponium.add([at1, at2, at3])
-    derponium.add_bond((at1, at2))
-    derponium.add_bond((at2, at3))
-
-    with pytest.raises(Exception):
-        ff.apply(derponium)
-    thing = ff.apply(derponium, assert_bond_params=False, assert_angle_params=False)
-    assert any(b.type is None for b in thing.bonds)
-
-@pytest.mark.parametrize("filename", ['ethane.mol2', 'benzene.mol2'])
-def test_write_xml(filename):
-    mol = pmd.load_file(get_fn(filename), structure=True)
-    oplsaa = Forcefield(name='oplsaa')
-    typed = oplsaa.apply(mol)
-
-    typed.write_foyer(filename='opls-snippet.xml', forcefield=oplsaa, unique=True)
-    oplsaa_partial = Forcefield('opls-snippet.xml')
-    typed_by_partial = oplsaa_partial.apply(mol)
-
-    for adj in typed.adjusts:
-        type1 = adj.atom1.atom_type
-        type2 = adj.atom1.atom_type
-        sigma_factor_pre = adj.type.sigma / ((type1.sigma + type2.sigma) / 2)
-        epsilon_factor_pre = adj.type.epsilon / ((type1.epsilon * type2.epsilon) ** 0.5)
-
-    for adj in typed_by_partial.adjusts:
-        type1 = adj.atom1.atom_type
-        type2 = adj.atom1.atom_type
-        sigma_factor_post = adj.type.sigma / ((type1.sigma + type2.sigma) / 2)
-        epsilon_factor_post = adj.type.epsilon / ((type1.epsilon * type2.epsilon) ** 0.5)
-
-    assert sigma_factor_pre == sigma_factor_post
-    assert epsilon_factor_pre == epsilon_factor_post
-
-    # Do it again but with an XML including periodic dihedrals
-    mol = pmd.load_file(get_fn(filename), structure=True)
-    oplsaa = Forcefield(get_fn('oplsaa-periodic.xml'))
-    typed = oplsaa.apply(mol)
-
-    typed.write_foyer(filename='opls-snippet.xml', forcefield=oplsaa, unique=True)
-    oplsaa_partial = Forcefield('opls-snippet.xml')
-    typed_by_partial = oplsaa_partial.apply(mol)
-
-    for adj in typed.adjusts:
-        type1 = adj.atom1.atom_type
-        type2 = adj.atom1.atom_type
-        sigma_factor_pre = adj.type.sigma / ((type1.sigma + type2.sigma) / 2)
-        epsilon_factor_pre = adj.type.epsilon / ((type1.epsilon * type2.epsilon) ** 0.5)
-
-    for adj in typed_by_partial.adjusts:
-        type1 = adj.atom1.atom_type
-        type2 = adj.atom1.atom_type
-        sigma_factor_post = adj.type.sigma / ((type1.sigma + type2.sigma) / 2)
-        epsilon_factor_post = adj.type.epsilon / ((type1.epsilon * type2.epsilon) ** 0.5)
-
-    assert sigma_factor_pre == sigma_factor_post
-    assert epsilon_factor_pre == epsilon_factor_post
+        ethane *= 2
+        oplsaa = Forcefield(name='oplsaa')
+        topo, NULL = generate_topology(ethane)
+        topo_with = oplsaa.run_atomtyping(topo, use_residue_map=True)
+        topo_without = oplsaa.run_atomtyping(topo, use_residue_map=False)
+        assert all([a.id for a in topo_with.atoms()][0])
+        assert all([a.id for a in topo_without.atoms()][0])
+        struct_with = pmd.openmm.load_topology(topo_with, oplsaa.createSystem(topo_with))
+        struct_without = pmd.openmm.load_topology(topo_without, oplsaa.createSystem(topo_without))
+        for atom_with, atom_without in zip(struct_with.atoms, struct_without.atoms):
+            assert atom_with.type == atom_without.type
+            b_with = atom_with.bond_partners
+            b_without = atom_without.bond_partners
+            assert [a0.type for a0 in b_with] == [a1.type for a1 in b_without]
+            assert [a0.idx for a0 in b_with] == [a1.idx for a1 in b_without]
+    
+    def test_independent_residues_molecules(self):
+        """Test to see that _check_independent_residues works for molecules."""
+        butane = Alkane(4)
+        structure = butane.to_parmed()
+        topo, NULL = generate_topology(structure)
+        assert _check_independent_residues(topo)
+        structure = butane.to_parmed(residues=['RES', 'CH3'])
+        topo, NULL = generate_topology(structure)
+        assert not _check_independent_residues(topo)
+    
+    @pytest.mark.skipif(not has_mbuild, reason="mbuild is not installed")
+    def test_independent_residues_atoms(self):
+        """Test to see that _check_independent_residues works for single aotms."""
+        argon = mb.Compound()
+        argon.name = 'Ar'
+        structure = argon.to_parmed()
+        topo, NULL = generate_topology(structure)
+        assert _check_independent_residues(topo)
+    
+    @pytest.mark.skipif(not has_mbuild, reason="mbuild is not installed")
+    def test_topology_precedence(self):
+        """Test to see if topology precedence is properly adhered to.
+    
+        This test uses a force field file where bond, angle, and dihedral
+        parameters are present with different counts of `type` definitions.
+        It checks that:
+            1. The parameters with the higher number of `type` definitions
+               are assigned (because they are given the highest precedence)
+            2. That if multiple definitions exist with the same number of
+               `type` definitions, that the convention from OpenMM is followed
+               whereby the definitions that occurs earliest in the XML is
+               assigned.
+        """
+        ethane = mb.load(get_fn('ethane.mol2'))
+        ff = Forcefield(forcefield_files=get_fn('ethane-topo-precedence.xml'))
+        typed_ethane = ff.apply(ethane)
+    
+        assert len([bond for bond in typed_ethane.bonds
+                    if round(bond.type.req, 2) == 1.15]) == 6
+        assert len([bond for bond in typed_ethane.bonds
+                    if round(bond.type.req, 2) == 1.6]) == 1
+        assert len([angle for angle in typed_ethane.angles
+                    if round(angle.type.theteq, 3) == 120.321]) == 6
+        assert len([angle for angle in typed_ethane.angles
+                    if round(angle.type.theteq, 3) == 97.403]) == 6
+        assert len([rb for rb in typed_ethane.rb_torsions
+                    if round(rb.type.c0, 3) == 0.287]) == 9
+    
+    @pytest.mark.skipif(not has_mbuild, reason="mbuild is not installed")
+    @pytest.mark.parametrize("ff_filename,kwargs", [
+        ("ethane-angle-typo.xml", {"assert_angle_params": False}),
+        ("ethane-dihedral-typo.xml", {"assert_dihedral_params": False})
+    ])
+    def test_missing_topo_params(self, ff_filename, kwargs):
+        """Test that the user is notified if not all topology parameters are found."""
+        ethane = mb.load(get_fn('ethane.mol2'))
+        oplsaa_with_typo = Forcefield(forcefield_files=get_fn(ff_filename))
+        with pytest.raises(Exception):
+            ethane = oplsaa_with_typo.apply(ethane)
+        with pytest.warns(UserWarning):
+            ethane = oplsaa_with_typo.apply(ethane, **kwargs)
+    
+    @pytest.mark.skipif(not has_mbuild, reason="mbuild is not installed")
+    def test_overrides_space(self):
+        ethane = mb.load(get_fn('ethane.mol2'))
+        ff = Forcefield(forcefield_files=get_fn('overrides-space.xml'))
+        typed_ethane = ff.apply(ethane)
+        assert typed_ethane.atoms[0].type == 'CT3'
+    
+    def test_assert_bonds(self):
+        ff = Forcefield(name='trappe-ua')
+    
+        derponium = mb.Compound()
+        at1 = mb.Particle(name='H')
+        at2 = mb.Particle(name='O')
+        at3 = mb.Particle(name='_CH4')
+    
+        derponium.add([at1, at2, at3])
+        derponium.add_bond((at1, at2))
+        derponium.add_bond((at2, at3))
+    
+        with pytest.raises(Exception):
+            ff.apply(derponium)
+        thing = ff.apply(derponium, assert_bond_params=False, assert_angle_params=False)
+        assert any(b.type is None for b in thing.bonds)
+    
+    @pytest.mark.parametrize("filename", ['ethane.mol2', 'benzene.mol2'])
+    def test_write_xml(self, filename):
+        mol = pmd.load_file(get_fn(filename), structure=True)
+        oplsaa = Forcefield(name='oplsaa')
+        typed = oplsaa.apply(mol)
+    
+        typed.write_foyer(filename='opls-snippet.xml', forcefield=oplsaa, unique=True)
+        oplsaa_partial = Forcefield('opls-snippet.xml')
+        typed_by_partial = oplsaa_partial.apply(mol)
+    
+        for adj in typed.adjusts:
+            type1 = adj.atom1.atom_type
+            type2 = adj.atom1.atom_type
+            sigma_factor_pre = adj.type.sigma / ((type1.sigma + type2.sigma) / 2)
+            epsilon_factor_pre = adj.type.epsilon / ((type1.epsilon * type2.epsilon) ** 0.5)
+    
+        for adj in typed_by_partial.adjusts:
+            type1 = adj.atom1.atom_type
+            type2 = adj.atom1.atom_type
+            sigma_factor_post = adj.type.sigma / ((type1.sigma + type2.sigma) / 2)
+            epsilon_factor_post = adj.type.epsilon / ((type1.epsilon * type2.epsilon) ** 0.5)
+    
+        assert sigma_factor_pre == sigma_factor_post
+        assert epsilon_factor_pre == epsilon_factor_post
+    
+        # Do it again but with an XML including periodic dihedrals
+        mol = pmd.load_file(get_fn(filename), structure=True)
+        oplsaa = Forcefield(get_fn('oplsaa-periodic.xml'))
+        typed = oplsaa.apply(mol)
+    
+        typed.write_foyer(filename='opls-snippet.xml', forcefield=oplsaa, unique=True)
+        oplsaa_partial = Forcefield('opls-snippet.xml')
+        typed_by_partial = oplsaa_partial.apply(mol)
+    
+        for adj in typed.adjusts:
+            type1 = adj.atom1.atom_type
+            type2 = adj.atom1.atom_type
+            sigma_factor_pre = adj.type.sigma / ((type1.sigma + type2.sigma) / 2)
+            epsilon_factor_pre = adj.type.epsilon / ((type1.epsilon * type2.epsilon) ** 0.5)
+    
+        for adj in typed_by_partial.adjusts:
+            type1 = adj.atom1.atom_type
+            type2 = adj.atom1.atom_type
+            sigma_factor_post = adj.type.sigma / ((type1.sigma + type2.sigma) / 2)
+            epsilon_factor_post = adj.type.epsilon / ((type1.epsilon * type2.epsilon) ** 0.5)
+    
+        assert sigma_factor_pre == sigma_factor_post
+        assert epsilon_factor_pre == epsilon_factor_post

--- a/foyer/tests/test_graph.py
+++ b/foyer/tests/test_graph.py
@@ -3,7 +3,7 @@ import parmed as pmd
 from foyer.forcefield import generate_topology
 from foyer.smarts_graph import SMARTSGraph, _prepare_atoms
 from foyer.tests.utils import get_fn
-
+from foyer.tests.base_test import BaseTest
 
 TEST_BANK = [
     'O([H&X1])(H)',
@@ -15,35 +15,36 @@ TEST_BANK = [
 ]
 
 
-def test_init():
-    """Initialization test. """
-    for smarts in TEST_BANK:
-        graph = SMARTSGraph(smarts)
-        atoms = graph.ast.find_data('atom')
-        for n, atom in enumerate(atoms):
-            assert n in graph.nodes()
-
-
-def test_lazy_cycle_finding():
-    mol2 = pmd.load_file(get_fn('ethane.mol2'), structure=True)
-    top, _ = generate_topology(mol2)
-
-    rule = SMARTSGraph(smarts_string='[C]')
-    list(rule.find_matches(top))
-    assert not any([hasattr(a, 'cycles') for a in top.atoms()])
-
-    ring_tokens = ['R1', 'r6']
-    for token in ring_tokens:
-        rule = SMARTSGraph(smarts_string='[C;{}]'.format(token))
+class TestGraph(BaseTest):
+    def test_init(self):
+        """Initialization test. """
+        for smarts in TEST_BANK:
+            graph = SMARTSGraph(smarts)
+            atoms = graph.ast.find_data('atom')
+            for n, atom in enumerate(atoms):
+                assert n in graph.nodes()
+    
+    
+    def test_lazy_cycle_finding(self):
+        mol2 = pmd.load_file(get_fn('ethane.mol2'), structure=True)
+        top, _ = generate_topology(mol2)
+    
+        rule = SMARTSGraph(smarts_string='[C]')
         list(rule.find_matches(top))
-        assert all([hasattr(a, 'cycles') for a in top.atoms()])
-
-
-def test_cycle_finding_multiple():
-    fullerene = pmd.load_file(get_fn('fullerene.pdb'), structure=True)
-    top, _ = generate_topology(fullerene)
-
-    _prepare_atoms(top, compute_cycles=True)
-    cycle_lengths = [list(map(len, atom.cycles)) for atom in top.atoms()]
-    expected = [5, 6, 6]
-    assert all(sorted(lengths) == expected for lengths in cycle_lengths)
+        assert not any([hasattr(a, 'cycles') for a in top.atoms()])
+    
+        ring_tokens = ['R1', 'r6']
+        for token in ring_tokens:
+            rule = SMARTSGraph(smarts_string='[C;{}]'.format(token))
+            list(rule.find_matches(top))
+            assert all([hasattr(a, 'cycles') for a in top.atoms()])
+    
+    
+    def test_cycle_finding_multiple(self):
+        fullerene = pmd.load_file(get_fn('fullerene.pdb'), structure=True)
+        top, _ = generate_topology(fullerene)
+    
+        _prepare_atoms(top, compute_cycles=True)
+        cycle_lengths = [list(map(len, atom.cycles)) for atom in top.atoms()]
+        expected = [5, 6, 6]
+        assert all(sorted(lengths) == expected for lengths in cycle_lengths)

--- a/foyer/tests/test_opls.py
+++ b/foyer/tests/test_opls.py
@@ -8,16 +8,13 @@ import pytest
 
 from foyer import Forcefield
 from foyer.tests.utils import atomtype
+from foyer.tests.base_test import BaseTest
 
 OPLSAA = Forcefield(name='oplsaa')
 
 OPLS_TESTFILES_DIR = resource_filename('foyer', 'opls_validation')
 
-class TestOPLS(object):
-
-    @pytest.fixture(autouse=True)
-    def initdir(self, tmpdir):
-        tmpdir.chdir()
+class TestOPLS(BaseTest):
 
     top_files = glob.glob(os.path.join(OPLS_TESTFILES_DIR, '*/*.top'))
     mol2_files = glob.glob(os.path.join(OPLS_TESTFILES_DIR, '*/*.mol2'))

--- a/foyer/tests/test_performance.py
+++ b/foyer/tests/test_performance.py
@@ -5,26 +5,27 @@ import pytest
 from foyer import Forcefield
 from foyer.tests.utils import get_fn
 from foyer.utils.io import has_mbuild
+from foyer.tests.base_test import BaseTest
 
-
-@pytest.mark.timeout(1)
-def test_fullerene():
-    fullerene = pmd.load_file(get_fn('fullerene.pdb'), structure=True)
-    forcefield = Forcefield(get_fn('fullerene.xml'))
-    forcefield.apply(fullerene, assert_dihedral_params=False)
-
-
-@pytest.mark.skipif(not has_mbuild, reason="mbuild is not installed")
-@pytest.mark.timeout(15)
-def test_surface():
-    surface = mb.load(get_fn('silica.mol2'))
-    forcefield = Forcefield(get_fn('opls-silica.xml'))
-    forcefield.apply(surface, assert_bond_params=False)
-
-
-@pytest.mark.skipif(not has_mbuild, reason="mbuild is not installed")
-@pytest.mark.timeout(45)
-def test_polymer():
-    peg100 = mb.load(get_fn('peg100.mol2'))
-    forcefield = Forcefield(name='oplsaa')
-    forcefield.apply(peg100)
+class TestPerformance(BaseTest):
+    @pytest.mark.timeout(1)
+    def test_fullerene(self):
+        fullerene = pmd.load_file(get_fn('fullerene.pdb'), structure=True)
+        forcefield = Forcefield(get_fn('fullerene.xml'))
+        forcefield.apply(fullerene, assert_dihedral_params=False)
+    
+    
+    @pytest.mark.skipif(not has_mbuild, reason="mbuild is not installed")
+    @pytest.mark.timeout(15)
+    def test_surface(self):
+        surface = mb.load(get_fn('silica.mol2'))
+        forcefield = Forcefield(get_fn('opls-silica.xml'))
+        forcefield.apply(surface, assert_bond_params=False)
+    
+    
+    @pytest.mark.skipif(not has_mbuild, reason="mbuild is not installed")
+    @pytest.mark.timeout(45)
+    def test_polymer(self):
+        peg100 = mb.load(get_fn('peg100.mol2'))
+        forcefield = Forcefield(name='oplsaa')
+        forcefield.apply(peg100)

--- a/foyer/tests/test_smarts.py
+++ b/foyer/tests/test_smarts.py
@@ -7,10 +7,190 @@ from foyer.forcefield import generate_topology, Forcefield
 from foyer.smarts_graph import SMARTSGraph
 from foyer.smarts import SMARTS
 from foyer.tests.utils import get_fn
+from foyer.tests.base_test import BaseTest
 
 
 PARSER = SMARTS()
-
+class TestSMARTS(BaseTest):
+    
+    
+    def test_ast(self):
+        ast = PARSER.parse('O([H&X1])(H)')
+        assert ast.data == "start"
+        assert ast.children[0].data == "atom"
+        assert ast.children[0].children[0].data == "atom_symbol"
+        assert str(ast.children[0].children[0].children[0]) == "O"
+    
+    
+    def test_parse(self):
+        smarts = ['[#6][#1](C)H',
+                  '[O;X2]([C;X4](F)(*)(*))[C;X4]']
+        for pattern in smarts:
+            ast = PARSER.parse(pattern)
+    
+    
+    def test_uniqueness(self):
+        mol2 = pmd.load_file(get_fn('uniqueness_test.mol2'), structure=True)
+        top, _ = generate_topology(mol2)
+    
+        _rule_match(top, '[#6]1[#6][#6][#6][#6][#6]1', False)
+        _rule_match(top, '[#6]1[#6][#6][#6][#6]1', False)
+        _rule_match(top, '[#6]1[#6][#6][#6]1', True)
+    
+    
+    def test_ringness(self):
+        ring = pmd.load_file(get_fn('ring.mol2'), structure=True)
+        top, _ = generate_topology(ring)
+        _rule_match(top, '[#6]1[#6][#6][#6][#6][#6]1', True)
+    
+        not_ring = pmd.load_file(get_fn('not_ring.mol2'), structure=True)
+        top, _ = generate_topology(not_ring)
+        _rule_match(top, '[#6]1[#6][#6][#6][#6][#6]1', False)
+    
+    
+    def test_fused_ring(self):
+        fused = pmd.load_file(get_fn('fused.mol2'), structure=True)
+        top, _ = generate_topology(fused)
+        rule = SMARTSGraph(name='test', parser=PARSER,
+                           smarts_string='[#6]12[#6][#6][#6][#6][#6]1[#6][#6][#6][#6]2')
+    
+        match_indices = list(rule.find_matches(top))
+        assert 3 in match_indices
+        assert 4 in match_indices
+        assert len(match_indices) == 2
+    
+    
+    def test_ring_count(self):
+        # Two rings
+        fused = pmd.load_file(get_fn('fused.mol2'), structure=True)
+        top, _ = generate_topology(fused)
+        rule = SMARTSGraph(name='test', parser=PARSER,
+                           smarts_string='[#6;R2]')
+    
+        match_indices = list(rule.find_matches(top))
+        for atom_idx in (3, 4):
+            assert atom_idx in match_indices
+        assert len(match_indices) == 2
+    
+        rule = SMARTSGraph(name='test', parser=PARSER,
+                           smarts_string='[#6;R1]')
+        match_indices = list(rule.find_matches(top))
+        for atom_idx in (0, 1, 2, 5, 6, 7, 8, 9):
+            assert atom_idx in match_indices
+        assert len(match_indices) == 8
+    
+        # One ring
+        ring = pmd.load_file(get_fn('ring.mol2'), structure=True)
+        top, _ = generate_topology(ring)
+    
+        rule = SMARTSGraph(name='test', parser=PARSER,
+                           smarts_string='[#6;R1]')
+        match_indices = list(rule.find_matches(top))
+        for atom_idx in range(6):
+            assert atom_idx in match_indices
+        assert len(match_indices) == 6
+    
+    
+    def test_precedence_ast(self):
+        ast1 = PARSER.parse('[C,H;O]')
+        ast2 = PARSER.parse('[O;H,C]')
+        assert ast1.children[0].children[0].data == 'weak_and_expression'
+        assert ast2.children[0].children[0].data == 'weak_and_expression'
+    
+        assert ast1.children[0].children[0].children[0].data == 'or_expression'
+        assert ast2.children[0].children[0].children[1].data == 'or_expression'
+    
+        ast1 = PARSER.parse('[C,H&O]')
+        ast2 = PARSER.parse('[O&H,C]')
+        assert ast1.children[0].children[0].data == 'or_expression'
+        assert ast2.children[0].children[0].data == 'or_expression'
+    
+        assert ast1.children[0].children[0].children[1].data == 'and_expression'
+        assert ast2.children[0].children[0].children[0].data == 'and_expression'
+    
+    
+    def test_precedence(self):
+        mol2 = pmd.load_file(get_fn('ethane.mol2'), structure=True)
+        top, _ = generate_topology(mol2)
+    
+        checks = {'[C,O;C]': 2,
+                  '[C&O;C]': 0,
+                  '[!C;O,C]': 0,
+                  '[!C&O,C]': 2,
+                  }
+    
+        for smart, result in checks.items():
+            _rule_match_count(top, smart, result)
+    
+    
+    def test_not_ast(self):
+        checks = {'[!C;!H]': 'weak_and_expression',
+                  '[!C&H]': 'and_expression',
+                  '[!C;H]': 'weak_and_expression',
+                  '[!C]': 'not_expression'}
+    
+        for smart, grandchild in checks.items():
+            ast = PARSER.parse(smart)
+            assert ast.children[0].children[0].data == grandchild
+    
+        illegal_nots = ['[!CH]', '[!C!H]']
+        for smart in illegal_nots:
+            with pytest.raises(lark.UnexpectedInput):
+                PARSER.parse(smart)
+    
+    
+    def test_not(self):
+        mol2 = pmd.load_file(get_fn('ethane.mol2'), structure=True)
+        top, _ = generate_topology(mol2)
+    
+        checks = {'[!O]': 8,
+                  '[!#5]': 8,
+                  '[!C]': 6,
+                  '[!#6]': 6,
+                  '[!C&!H]': 0,
+                  '[!C;!H]': 0,
+                  }
+        for smart, result in checks.items():
+            _rule_match_count(top, smart, result)
+    
+    
+    def test_hexa_coordinated(self):
+        ff = Forcefield(forcefield_files=get_fn('pf6.xml'))
+        mol2 = pmd.load_file(get_fn('pf6.mol2'), structure=True)
+    
+        pf6 = ff.apply(mol2)
+    
+        types = [a.type for a in pf6.atoms]
+        assert types.count('P') == 1
+        assert types.count('F1') == 2
+        assert types.count('F2') == 2
+        assert types.count('F3') == 2
+    
+        assert len(pf6.bonds) == 6
+        assert all(bond.type for bond in pf6.bonds)
+    
+        assert len(pf6.angles) == 15
+        assert all(angle.type for angle in pf6.angles)
+    
+    
+    def test_optional_names_bad_syntax(self):
+        bad_optional_names = ['_C', 'XXX', 'C']
+        with pytest.raises(FoyerError):
+            S = SMARTS(optional_names=bad_optional_names)
+    
+    
+    def test_optional_names_good_syntax(self):
+        good_optional_names = ['_C', '_CH2', '_CH']
+        S = SMARTS(optional_names=good_optional_names)
+    
+    
+    def test_optional_name_parser(self):
+        optional_names = ['_C', '_CH2', '_CH']
+        S = SMARTS(optional_names=optional_names)
+        ast = S.parse('_CH2_C_CH')
+        symbols = [a.children[0] for a in ast.find_data('atom_symbol')]
+        for name in optional_names:
+            assert name in symbols
 
 def _rule_match(top, smart, result):
     rule = SMARTSGraph(name='test', parser=PARSER, smarts_string=smart)
@@ -20,182 +200,3 @@ def _rule_match(top, smart, result):
 def _rule_match_count(top, smart, count):
     rule = SMARTSGraph(name='test', parser=PARSER, smarts_string=smart)
     assert len(list(rule.find_matches(top))) is count
-
-
-def test_ast():
-    ast = PARSER.parse('O([H&X1])(H)')
-    assert ast.data == "start"
-    assert ast.children[0].data == "atom"
-    assert ast.children[0].children[0].data == "atom_symbol"
-    assert str(ast.children[0].children[0].children[0]) == "O"
-
-
-def test_parse():
-    smarts = ['[#6][#1](C)H',
-              '[O;X2]([C;X4](F)(*)(*))[C;X4]']
-    for pattern in smarts:
-        ast = PARSER.parse(pattern)
-
-
-def test_uniqueness():
-    mol2 = pmd.load_file(get_fn('uniqueness_test.mol2'), structure=True)
-    top, _ = generate_topology(mol2)
-
-    _rule_match(top, '[#6]1[#6][#6][#6][#6][#6]1', False)
-    _rule_match(top, '[#6]1[#6][#6][#6][#6]1', False)
-    _rule_match(top, '[#6]1[#6][#6][#6]1', True)
-
-
-def test_ringness():
-    ring = pmd.load_file(get_fn('ring.mol2'), structure=True)
-    top, _ = generate_topology(ring)
-    _rule_match(top, '[#6]1[#6][#6][#6][#6][#6]1', True)
-
-    not_ring = pmd.load_file(get_fn('not_ring.mol2'), structure=True)
-    top, _ = generate_topology(not_ring)
-    _rule_match(top, '[#6]1[#6][#6][#6][#6][#6]1', False)
-
-
-def test_fused_ring():
-    fused = pmd.load_file(get_fn('fused.mol2'), structure=True)
-    top, _ = generate_topology(fused)
-    rule = SMARTSGraph(name='test', parser=PARSER,
-                       smarts_string='[#6]12[#6][#6][#6][#6][#6]1[#6][#6][#6][#6]2')
-
-    match_indices = list(rule.find_matches(top))
-    assert 3 in match_indices
-    assert 4 in match_indices
-    assert len(match_indices) == 2
-
-
-def test_ring_count():
-    # Two rings
-    fused = pmd.load_file(get_fn('fused.mol2'), structure=True)
-    top, _ = generate_topology(fused)
-    rule = SMARTSGraph(name='test', parser=PARSER,
-                       smarts_string='[#6;R2]')
-
-    match_indices = list(rule.find_matches(top))
-    for atom_idx in (3, 4):
-        assert atom_idx in match_indices
-    assert len(match_indices) == 2
-
-    rule = SMARTSGraph(name='test', parser=PARSER,
-                       smarts_string='[#6;R1]')
-    match_indices = list(rule.find_matches(top))
-    for atom_idx in (0, 1, 2, 5, 6, 7, 8, 9):
-        assert atom_idx in match_indices
-    assert len(match_indices) == 8
-
-    # One ring
-    ring = pmd.load_file(get_fn('ring.mol2'), structure=True)
-    top, _ = generate_topology(ring)
-
-    rule = SMARTSGraph(name='test', parser=PARSER,
-                       smarts_string='[#6;R1]')
-    match_indices = list(rule.find_matches(top))
-    for atom_idx in range(6):
-        assert atom_idx in match_indices
-    assert len(match_indices) == 6
-
-
-def test_precedence_ast():
-    ast1 = PARSER.parse('[C,H;O]')
-    ast2 = PARSER.parse('[O;H,C]')
-    assert ast1.children[0].children[0].data == 'weak_and_expression'
-    assert ast2.children[0].children[0].data == 'weak_and_expression'
-
-    assert ast1.children[0].children[0].children[0].data == 'or_expression'
-    assert ast2.children[0].children[0].children[1].data == 'or_expression'
-
-    ast1 = PARSER.parse('[C,H&O]')
-    ast2 = PARSER.parse('[O&H,C]')
-    assert ast1.children[0].children[0].data == 'or_expression'
-    assert ast2.children[0].children[0].data == 'or_expression'
-
-    assert ast1.children[0].children[0].children[1].data == 'and_expression'
-    assert ast2.children[0].children[0].children[0].data == 'and_expression'
-
-
-def test_precedence():
-    mol2 = pmd.load_file(get_fn('ethane.mol2'), structure=True)
-    top, _ = generate_topology(mol2)
-
-    checks = {'[C,O;C]': 2,
-              '[C&O;C]': 0,
-              '[!C;O,C]': 0,
-              '[!C&O,C]': 2,
-              }
-
-    for smart, result in checks.items():
-        _rule_match_count(top, smart, result)
-
-
-def test_not_ast():
-    checks = {'[!C;!H]': 'weak_and_expression',
-              '[!C&H]': 'and_expression',
-              '[!C;H]': 'weak_and_expression',
-              '[!C]': 'not_expression'}
-
-    for smart, grandchild in checks.items():
-        ast = PARSER.parse(smart)
-        assert ast.children[0].children[0].data == grandchild
-
-    illegal_nots = ['[!CH]', '[!C!H]']
-    for smart in illegal_nots:
-        with pytest.raises(lark.UnexpectedInput):
-            PARSER.parse(smart)
-
-
-def test_not():
-    mol2 = pmd.load_file(get_fn('ethane.mol2'), structure=True)
-    top, _ = generate_topology(mol2)
-
-    checks = {'[!O]': 8,
-              '[!#5]': 8,
-              '[!C]': 6,
-              '[!#6]': 6,
-              '[!C&!H]': 0,
-              '[!C;!H]': 0,
-              }
-    for smart, result in checks.items():
-        _rule_match_count(top, smart, result)
-
-
-def test_hexa_coordinated():
-    ff = Forcefield(forcefield_files=get_fn('pf6.xml'))
-    mol2 = pmd.load_file(get_fn('pf6.mol2'), structure=True)
-
-    pf6 = ff.apply(mol2)
-
-    types = [a.type for a in pf6.atoms]
-    assert types.count('P') == 1
-    assert types.count('F1') == 2
-    assert types.count('F2') == 2
-    assert types.count('F3') == 2
-
-    assert len(pf6.bonds) == 6
-    assert all(bond.type for bond in pf6.bonds)
-
-    assert len(pf6.angles) == 15
-    assert all(angle.type for angle in pf6.angles)
-
-
-def test_optional_names_bad_syntax():
-    bad_optional_names = ['_C', 'XXX', 'C']
-    with pytest.raises(FoyerError):
-        S = SMARTS(optional_names=bad_optional_names)
-
-
-def test_optional_names_good_syntax():
-    good_optional_names = ['_C', '_CH2', '_CH']
-    S = SMARTS(optional_names=good_optional_names)
-
-
-def test_optional_name_parser():
-    optional_names = ['_C', '_CH2', '_CH']
-    S = SMARTS(optional_names=optional_names)
-    ast = S.parse('_CH2_C_CH')
-    symbols = [a.children[0] for a in ast.find_data('atom_symbol')]
-    for name in optional_names:
-        assert name in symbols

--- a/foyer/tests/test_trappe.py
+++ b/foyer/tests/test_trappe.py
@@ -8,16 +8,13 @@ import pytest
 
 from foyer import Forcefield
 from foyer.tests.utils import atomtype
+from foyer.tests.base_test import BaseTest
 
 TRAPPE_UA = Forcefield(name='trappe-ua')
 
 TRAPPE_TESTFILES_DIR = resource_filename('foyer', 'trappe_validation')
 
-class TestTraPPE(object):
-
-    @pytest.fixture(autouse=True)
-    def initdir(self, tmpdir):
-        tmpdir.chdir()
+class TestTraPPE(BaseTest):
 
     mol2_files = glob.glob(os.path.join(TRAPPE_TESTFILES_DIR, '*/*.mol2'))
 

--- a/foyer/tests/test_validator.py
+++ b/foyer/tests/test_validator.py
@@ -9,6 +9,7 @@ from foyer.tests.utils import glob_fn
 from foyer.exceptions import (ValidationError, ValidationWarning,
                              MultipleValidationError)
 from foyer.validator import Validator
+from foyer.tests.base_test import BaseTest
 
 XMLS = glob_fn('*.xml')
 ERRORS = {'validationerror': (ValidationError, MultipleValidationError),
@@ -20,23 +21,21 @@ FF_DIR = resource_filename('foyer', 'forcefields')
 FORCEFIELDS = glob.glob(os.path.join(FF_DIR, '*.xml'))
 
 
-@pytest.mark.parametrize('ff_file', XMLS)
-def test_xmls(ff_file):
-    file_name = os.path.split(ff_file)[1]
-    if 'error' in file_name:
-        error_type = ERRORS[file_name.split('_')[0]]
-        with pytest.raises(error_type):
+class TestValidator(BaseTest):
+    @pytest.mark.parametrize('ff_file', XMLS)
+    def test_xmls(self, ff_file):
+        file_name = os.path.split(ff_file)[1]
+        if 'error' in file_name:
+            error_type = ERRORS[file_name.split('_')[0]]
+            with pytest.raises(error_type):
+                Validator(ff_file)
+        elif file_name.startswith('warning'):
+            with pytest.warns(ValidationWarning):
+                Validator(ff_file)
+        else:
             Validator(ff_file)
-    elif file_name.startswith('warning'):
-        with pytest.warns(ValidationWarning):
-            Validator(ff_file)
-    else:
+    
+    
+    @pytest.mark.parametrize('ff_file', FORCEFIELDS)
+    def test_forcefields(self, ff_file):
         Validator(ff_file)
-
-
-@pytest.mark.parametrize('ff_file', FORCEFIELDS)
-def test_forcefields(ff_file):
-    Validator(ff_file)
-
-
-


### PR DESCRIPTION
### PR Summary:
We now have a few unit tests that check to see files can be written out. If you've seen a few `.bib` and XML files floating around the root directory of your `foyer` install, it's because these tests did not include the `pytest` fixture that chucks everything into a temporary directory and nukes it after the test completes. This PR makes that change, which isn't necessary for most tests but is a good practice in case other fixtures are added in the future.

Maybe 90% of these changes are tabbing unit tests over 4 spaces; I'm not sure why GitHub doesn't make the diffs look prettier than they do.

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
