### PR TITLE
Add conftest.py to store pytest fixtures

### DIFF
--- a/foyer/tests/conftest.py
+++ b/foyer/tests/conftest.py
@@ -1,0 +1,5 @@
+import pytest
+
+@pytest.fixture(scope="session")
+def initdir(tmpdir):
+    tmpdir.chdir()

--- a/foyer/tests/conftest.py
+++ b/foyer/tests/conftest.py
@@ -1,5 +1,5 @@
 import pytest
 
-@pytest.fixture(scope="session")
+@pytest.fixture(autouse=True)
 def initdir(tmpdir):
     tmpdir.chdir()

--- a/foyer/tests/test_forcefield.py
+++ b/foyer/tests/test_forcefield.py
@@ -76,7 +76,6 @@ def test_from_mbuild():
     assert len(ethane.rb_torsions) == 9
     assert all(x.type for x in ethane.dihedrals)
 
-@pytest.fixture(scope="session")
 @pytest.mark.skipif(not has_mbuild, reason="mbuild is not installed")
 def test_write_refs():
     mol2 = mb.load(get_fn('ethane.mol2'))
@@ -84,7 +83,6 @@ def test_write_refs():
     ethane = oplsaa.apply(mol2, references_file='ethane.bib')
     assert os.path.isfile('ethane.bib')
 
-@pytest.fixture(scope="session")
 @pytest.mark.skipif(not has_mbuild, reason="mbuild is not installed")
 def test_write_refs_multiple():
     mol2 = mb.load(get_fn('ethane.mol2'))
@@ -241,7 +239,6 @@ def test_assert_bonds():
     thing = ff.apply(derponium, assert_bond_params=False, assert_angle_params=False)
     assert any(b.type is None for b in thing.bonds)
 
-@pytest.fixture(scope="session")
 @pytest.mark.parametrize("filename", ['ethane.mol2', 'benzene.mol2'])
 def test_write_xml(filename):
     mol = pmd.load_file(get_fn(filename), structure=True)

--- a/foyer/tests/test_forcefield.py
+++ b/foyer/tests/test_forcefield.py
@@ -76,6 +76,7 @@ def test_from_mbuild():
     assert len(ethane.rb_torsions) == 9
     assert all(x.type for x in ethane.dihedrals)
 
+@pytest.fixture(scope="session")
 @pytest.mark.skipif(not has_mbuild, reason="mbuild is not installed")
 def test_write_refs():
     mol2 = mb.load(get_fn('ethane.mol2'))
@@ -83,6 +84,7 @@ def test_write_refs():
     ethane = oplsaa.apply(mol2, references_file='ethane.bib')
     assert os.path.isfile('ethane.bib')
 
+@pytest.fixture(scope="session")
 @pytest.mark.skipif(not has_mbuild, reason="mbuild is not installed")
 def test_write_refs_multiple():
     mol2 = mb.load(get_fn('ethane.mol2'))
@@ -239,6 +241,7 @@ def test_assert_bonds():
     thing = ff.apply(derponium, assert_bond_params=False, assert_angle_params=False)
     assert any(b.type is None for b in thing.bonds)
 
+@pytest.fixture(scope="session")
 @pytest.mark.parametrize("filename", ['ethane.mol2', 'benzene.mol2'])
 def test_write_xml(filename):
     mol = pmd.load_file(get_fn(filename), structure=True)


### PR DESCRIPTION
### PR Summary:
Same idea as #242 but using @ctk3b's suggestion of `@pytest.fixture(scope="session")`

Can't really verify on CI that the extraneous files aren't being written, but they're not in my local directory. Somebody else should grab these changes and runs tests to see that it works for them as well.

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
