### PR TITLE
Openmm 73 patch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,11 @@ matrix:
     - { os: linux, env: PYTHON_VERSION=2.7 }
     - { os: linux, env: PYTHON_VERSION=3.5 }
     - { os: linux, env: PYTHON_VERSION=3.6 }
+    - { os: linux, env: PYTHON_VERSION=3.7 }
     - { os: osx, env: PYTHON_VERSION=2.7 }
     - { os: osx, env: PYTHON_VERSION=3.5 }
     - { os: osx, env: PYTHON_VERSION=3.6 }
+    - { os: osx, env: PYTHON_VERSION=3.7 }
 
 env:
   global:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,10 @@ environment:
     - PYTHON: "C:\\Miniconda36-x64"
       CONDA_PY: "36"
       ARCH: "64"
+    - PYTHON: "C:\\Miniconda36-x64"
+      CONDA_PY: "37"
+      ARCH: "64"
+
 
 install:
   - set PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -19,7 +19,7 @@ requirements:
     - parmed
     - networkx >=2.0
     - six
-    - openmm <7.3
+    - openmm
     - lark-parser
     - requests
     - lxml

--- a/foyer/forcefield.py
+++ b/foyer/forcefield.py
@@ -590,6 +590,8 @@ class Forcefield(app.ForceField):
             The mass to use for hydrogen atoms bound to heavy atoms.  Any mass
             added to a hydrogen is subtracted from the heavy atom to keep
             their total mass the same.
+        switchDistance : float=None
+            The distance at which the potential energy switching function is turned on for
         args
              Arbitrary additional keyword arguments may also be specified.
              This allows extra parameters to be specified that are specific to

--- a/foyer/forcefield.py
+++ b/foyer/forcefield.py
@@ -602,7 +602,7 @@ class Forcefield(app.ForceField):
         system
             the newly created System
         """
-        args['switchDistance'] = None
+        args['switchDistance'] = switchDistance
         # Overwrite previous _SystemData object
         self._SystemData = app.ForceField._SystemData()
 

--- a/foyer/forcefield.py
+++ b/foyer/forcefield.py
@@ -434,7 +434,9 @@ class Forcefield(app.ForceField):
         #kwargs['switchDistance'] = None
         #system = self.createSystem(topology, *args, **kwargs)
         # Option 2: Explicitly specify switchDistance 
-        system = self.createSystem(topology, switchDistance=None, *args, **kwargs)
+        #system = self.createSystem(topology, switchDistance=None, *args, **kwargs)
+        # Option 3: Default kwarg in createSystem
+        system = self.createSystem(topology, *args, **kwargs)
         _separate_urey_bradleys(system, topology)
 
         structure = pmd.openmm.load_topology(topology=topology, system=system)
@@ -563,6 +565,7 @@ class Forcefield(app.ForceField):
     def createSystem(self, topology, nonbondedMethod=NoCutoff,
                      nonbondedCutoff=1.0 * u.nanometer, constraints=None,
                      rigidWater=True, removeCMMotion=True, hydrogenMass=None,
+                     switchDistance=None,
                      **args):
         """Construct an OpenMM System representing a Topology with this force field.
 
@@ -597,7 +600,7 @@ class Forcefield(app.ForceField):
         system
             the newly created System
         """
-
+        args['switchDistance'] = None
         # Overwrite previous _SystemData object
         self._SystemData = app.ForceField._SystemData()
 

--- a/foyer/forcefield.py
+++ b/foyer/forcefield.py
@@ -429,7 +429,12 @@ class Forcefield(app.ForceField):
             positions[:] = np.nan
         box_vectors = topology.getPeriodicBoxVectors()
         topology = self.run_atomtyping(topology, use_residue_map=use_residue_map)
-        system = self.createSystem(topology, *args, **kwargs)
+        # Extra args to make OMM 7.3 happy
+        # Option 1: Add to the kwargs dictionary
+        #kwargs['switchDistance'] = None
+        #system = self.createSystem(topology, *args, **kwargs)
+        # Option 2: Explicitly specify switchDistance 
+        system = self.createSystem(topology, switchDistance=None, *args, **kwargs)
         _separate_urey_bradleys(system, topology)
 
         structure = pmd.openmm.load_topology(topology=topology, system=system)

--- a/foyer/tests/test_forcefield.py
+++ b/foyer/tests/test_forcefield.py
@@ -184,8 +184,8 @@ def test_residue_map():
     topo_without = oplsaa.run_atomtyping(topo, use_residue_map=False)
     assert all([a.id for a in topo_with.atoms()][0])
     assert all([a.id for a in topo_without.atoms()][0])
-    struct_with = pmd.openmm.load_topology(topo_with, oplsaa.createSystem(topo_with, switchDistance=None))
-    struct_without = pmd.openmm.load_topology(topo_without, oplsaa.createSystem(topo_without, switchDistance=None))
+    struct_with = pmd.openmm.load_topology(topo_with, oplsaa.createSystem(topo_with))
+    struct_without = pmd.openmm.load_topology(topo_without, oplsaa.createSystem(topo_without))
     for atom_with, atom_without in zip(struct_with.atoms, struct_without.atoms):
         assert atom_with.type == atom_without.type
         b_with = atom_with.bond_partners

--- a/foyer/tests/test_forcefield.py
+++ b/foyer/tests/test_forcefield.py
@@ -184,8 +184,8 @@ def test_residue_map():
     topo_without = oplsaa.run_atomtyping(topo, use_residue_map=False)
     assert all([a.id for a in topo_with.atoms()][0])
     assert all([a.id for a in topo_without.atoms()][0])
-    struct_with = pmd.openmm.load_topology(topo_with, oplsaa.createSystem(topo_with))
-    struct_without = pmd.openmm.load_topology(topo_without, oplsaa.createSystem(topo_without))
+    struct_with = pmd.openmm.load_topology(topo_with, oplsaa.createSystem(topo_with, switchDistance=None))
+    struct_without = pmd.openmm.load_topology(topo_without, oplsaa.createSystem(topo_without, switchDistance=None))
     for atom_with, atom_without in zip(struct_with.atoms, struct_without.atoms):
         assert atom_with.type == atom_without.type
         b_with = atom_with.bond_partners

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-openmm < 7.3
+openmm
 mbuild
 parmed
 networkx >=2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-openmm < 7.3
+openmm
 parmed
 networkx >=2.0
 six


### PR DESCRIPTION
### PR Summary:
Addresses #188 . This allows the use of Openmm 7.3 in with Foyer. The issue was the `createSystem`. OMM 7.2 didn't have default kwargs for `switchDistance`; in OMM 7.3, their `omm.FF.createSystem()` now added a default kwarg for `switchDistance`, which got added to the arguments passed to `force.createForce()`. I think we just needed to add a default kwarg to `switchDistance` in `foyer.FF.createSystem()` such that this argument gets passed into `force.createForce()` in the Foyer code. 

There are some extra commits and comments in the code here - I have multiple "options" to accommodate this switchDistance issue. If we go with the default kwarg in `foyer.ff.createSystem()`, we don't need to modify any tests. Some other options/code I explored were manually specifying the `switchDistance=None` in some parts of `apply()` routine, but that would then involve modifying `test_residue_map` because that unit test doesn't actually use the entire `apply()` routine, but rather snippets of the code inside the `apply()` routine. 

Tests passed locally on a py37 environment with `openmm=7.3.1` I don't think I need to add a unit test?
### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [x] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [x] Issue(s) raised/addressed?
