### PR TITLE
Enforce deletion of temporary XML files

### DIFF
--- a/foyer/validator.py
+++ b/foyer/validator.py
@@ -1,4 +1,5 @@
 from collections import Counter
+import os
 from os.path import join, split, abspath
 from warnings import warn
 
@@ -14,20 +15,24 @@ from foyer.smarts_graph import SMARTSGraph
 class Validator(object):
     def __init__(self, ff_file_name, debug=False):
         from foyer.forcefield import preprocess_forcefield_files
-        preprocessed_ff_file_name = preprocess_forcefield_files([ff_file_name])
+        try:
+            preprocessed_ff_file_name = preprocess_forcefield_files([ff_file_name])
 
-        ff_tree = etree.parse(preprocessed_ff_file_name[0])
-        self.validate_xsd(ff_tree)
+            ff_tree = etree.parse(preprocessed_ff_file_name[0])
+            self.validate_xsd(ff_tree)
 
-        self.atom_type_names = ff_tree.xpath('/ForceField/AtomTypes/Type/@name')
-        self.atom_types = ff_tree.xpath('/ForceField/AtomTypes/Type')
+            self.atom_type_names = ff_tree.xpath('/ForceField/AtomTypes/Type/@name')
+            self.atom_types = ff_tree.xpath('/ForceField/AtomTypes/Type')
 
-        self.validate_class_type_exclusivity(ff_tree)
+            self.validate_class_type_exclusivity(ff_tree)
 
-        # Loading forcefield should succeed, because XML can be parsed and
-        # basics have been validated.
-        from foyer.forcefield import Forcefield
-        self.smarts_parser = Forcefield(preprocessed_ff_file_name, validation=False).parser
+            # Loading forcefield should succeed, because XML can be parsed and
+            # basics have been validated.
+            from foyer.forcefield import Forcefield
+            self.smarts_parser = Forcefield(preprocessed_ff_file_name, validation=False).parser
+        finally:
+            for ff_file_name in preprocessed_ff_file_name:
+                os.remove(ff_file_name)
 
         self.validate_smarts(debug=debug)
         self.validate_overrides()


### PR DESCRIPTION
### PR Summary:
Change the temporary file creation from `tempfile.mkstemp` to
`tempfile.NamedTemporaryFile`.

`mkstemp` creates a temporary file with a file handle that can be
accessed in a secure manner, preventing possible race conditions.
However, `mkstemp` also requires _manual_ deletion of the file
after its purpose has been served.

This file was never being deleted, and would pollute the `$TMPDIR`
of the user who was running `Foyer`.

Instances of `mkstemp` have been replaced with `NamedTemporaryFile`,
which provides a higher level interface to created temp files,
and all instances where these are used are captured in `try,finally`
blocks, to ensure that they are removed after the XML files have been
processed.

Resolves #244 

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [x] Issue(s) raised/addressed?
