### PR TITLE
Drop Python 2.7 from travis and docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,8 @@ sudo: false
 
 matrix:
   include:
-    - { os: linux, env: PYTHON_VERSION=2.7 }
     - { os: linux, env: PYTHON_VERSION=3.6 }
     - { os: linux, env: PYTHON_VERSION=3.7 }
-    - { os: osx, env: PYTHON_VERSION=2.7 }
     - { os: osx, env: PYTHON_VERSION=3.6 }
     - { os: osx, env: PYTHON_VERSION=3.7 }
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -7,6 +7,12 @@ Install from conda:
 
     conda install -c conda-forge -c omnia -c mosdef foyer
 
+Install from pip:
+
+.. code:: bash
+
+    pip install foyer
+
 Install an editable version from source:
 
 .. code:: bash
@@ -14,3 +20,20 @@ Install an editable version from source:
     git clone https://github.com/mosdef-hub/foyer.git
     cd foyer
     pip install -e .
+
+Supported Python Versions
+-------------------------
+
+Python 3.6 and 3.7 are officially supported, including testing during
+development and packaging. Other Python versions, such as 3.8 and 3.5 and
+older, may successfully build and function but no guarantee is made.
+
+Testing your installation
+-------------------------
+
+foyer uses ``py.test`` for unit testing. To run them simply type run the
+following while in the base directory::
+
+    $ conda install pytest
+    $ py.test -v
+


### PR DESCRIPTION
### PR Summary:

Bye Felicia

#200 

Also updated the installation docs, mostly copying from mbuild. Not sure what else can/should be dropped, maybe codecov will find some things?

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [x] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [x] Issue(s) raised/addressed?
