### PR TITLE
Increased support of amide atomtyping with OPLS-AA.

### DIFF
--- a/foyer/forcefields/oplsaa.xml
+++ b/foyer/forcefields/oplsaa.xml
@@ -236,15 +236,15 @@
   <Type name="opls_234" class="opls_234" element="C" mass="12.011"/>
   <Type name="opls_235" class="C" element="C" mass="12.011" def="[C;X3]([O;X1])[N;X3]" desc="C=O in amide, dmf, peptide bond" overrides="opls_277" doi="10.1021/ja9621760"/>
   <Type name="opls_236" class="O" element="O" mass="15.9994" def="O[C;%opls_235]" desc="O: C=O in amide.   Acyl R on C in amide is neutral -" overrides="opls_278" doi="10.1021/ja9621760"/>
-  <Type name="opls_237" class="opls_237" element="N" mass="14.0067"/>
-  <Type name="opls_238" class="opls_238" element="N" mass="14.0067"/>
-  <Type name="opls_239" class="N" element="N" mass="14.0067" def="[N;X3]([!H])([!H])([!H])" desc="N: tertiary amide" doi="10.1021/ja9621760"/>
+  <Type name="opls_237" class="N" element="N" mass="14.0067" def="[N;X3](H)(H)([C;X3]([0;X1]))" desc="primary amide N, ex. carboxamide" doi="10.1021/ja9621760"/>
+  <Type name="opls_238" class="N" element="N" mass="14.0067" def="[N;X3](H)([C;X3]([O;X1])(C)" desc="secondary amide N, ex. NML" doi="10.1021/ja9621760"/>
+  <Type name="opls_239" class="N" element="N" mass="14.0067" def="[N;X3]([!H])([!H])([!H])" desc="tertiary amide N" doi="10.1021/ja9621760"/>
   <Type name="opls_240" class="opls_240" element="H" mass="1.008"/>
   <Type name="opls_241" class="opls_241" element="H" mass="1.008"/>
   <Type name="opls_242" class="opls_242" element="C" mass="12.011"/>
-  <Type name="opls_243" class="CT" element="C" mass="12.011" def="[C;X4](H)(H)(H)[N;X3](C)(C)" desc="C on N: tertiary  N-Me amide" doi="10.1021/ja9621760"/>
+  <Type name="opls_243" class="CT" element="C" mass="12.011" def="[C;X4](H)(H)(H)[N;X3](C)(C)" desc="C on N: tertiary N-Me amide, primary carbon." doi="10.1021/ja9621760"/>
   <Type name="opls_244" class="opls_244" element="C" mass="12.011"/>
-  <Type name="opls_245" class="opls_245" element="C" mass="12.011"/>
+  <Type name="opls_245" class="CT" element="C" mass="12.011" def="[C;X4](C)(H)(H)[N;X3](C)(C)" desc="C on N: tertiary N-Me amide, secondary carbon. ex. NMP." doi="10.1021/ja9621760"/>
   <Type name="opls_246" class="opls_246" element="C" mass="12.011"/>
   <Type name="opls_247" class="opls_247" element="C" mass="12.011"/>
   <Type name="opls_248" class="opls_248" element="O" mass="15.9994"/>

--- a/foyer/forcefields/oplsaa.xml
+++ b/foyer/forcefields/oplsaa.xml
@@ -236,15 +236,15 @@
   <Type name="opls_234" class="opls_234" element="C" mass="12.011"/>
   <Type name="opls_235" class="C" element="C" mass="12.011" def="[C;X3]([O;X1])[N;X3]" desc="C=O in amide, dmf, peptide bond" overrides="opls_277" doi="10.1021/ja9621760"/>
   <Type name="opls_236" class="O" element="O" mass="15.9994" def="O[C;%opls_235]" desc="O: C=O in amide.   Acyl R on C in amide is neutral -" overrides="opls_278" doi="10.1021/ja9621760"/>
-  <Type name="opls_237" class="N" element="N" mass="14.0067" def="[N;X3](H)(H)([C;X3]([O;X1]))" desc="primary amide N, ex. carboxamide" doi="10.1021/ja9621760"/>
-  <Type name="opls_238" class="N" element="N" mass="14.0067" def="[N;X3](H)([C;X3]([O;X1]))(C)" desc="secondary amide N, ex. NML" doi="10.1021/ja9621760"/>
-  <Type name="opls_239" class="N" element="N" mass="14.0067" def="[N;X3]([!H])([!H])([!H])" desc="tertiary amide N" doi="10.1021/ja9621760"/>
-  <Type name="opls_240" class="opls_240" element="H" mass="1.008"/>
-  <Type name="opls_241" class="opls_241" element="H" mass="1.008"/>
-  <Type name="opls_242" class="opls_242" element="C" mass="12.011"/>
-  <Type name="opls_243" class="CT" element="C" mass="12.011" def="[C;X4](H)(H)(H)[N;X3](C)(C)" desc="C on N: tertiary N-Me amide, primary carbon." doi="10.1021/ja9621760"/>
-  <Type name="opls_244" class="opls_244" element="C" mass="12.011"/>
-  <Type name="opls_245" class="CT" element="C" mass="12.011" def="[C;X4](C)(H)(H)[N;X3](C)(C)" desc="C on N: tertiary N-Me amide, secondary carbon. ex. NMP." doi="10.1021/ja9621760"/>
+  <Type name="opls_237" class="N" element="N" mass="14.0067" def="[N;X3](H)(H)[C;%opls_235]" desc="primary amide N, ex. carboxamide" overrides="opls_900" doi="10.1021/ja9621760"/>
+  <Type name="opls_238" class="N" element="N" mass="14.0067" def="[N;X3](H)(C)[C;%opls_235]" desc="secondary amide N, ex. N-methyl acetamide" doi="10.1021/ja9621760"/>
+  <Type name="opls_239" class="N" element="N" mass="14.0067" def="[N;X3](C)(C)[C;%opls_235]" desc="tertiary amide N, ex. acetamide" doi="10.1021/ja9621760"/>
+  <Type name="opls_240" class="H" element="H" mass="1.008" def="[H;X1][N;%opls_237]" desc="H on a primary nitrogen in amide" overrides="opls_909" doi="10.1021/ja9621760"/>
+  <Type name="opls_241" class="H" element="H" mass="1.008" def="[H;X1][N;%opls_238]" desc="H on a secondary nitrogen in amide" doi="10.1021/ja9621760"/>
+  <Type name="opls_242" class="CT" element="C" mass="12.011" def="[C;X4](H)(H)(H)[N;%opls_238]" desc="methyl C attached to secondary N in amide" doi="10.1021/ja9621760"/>
+  <Type name="opls_243" class="CT" element="C" mass="12.011" def="[C;X4](H)(H)(H)[N;%opls_239]" desc="methyl C attached to tertiary N in amide" doi="10.1021/ja9621760"/>
+  <Type name="opls_244" class="opls_244" element="C" mass="12.011"/> 
+  <Type name="opls_245" class="CT" element="C" mass="12.011" def="[C;X4](C)(H)(H)[N;%opls_239]" desc="secondary C attached to tertiary N. ex. NMP." doi="10.1021/ja9621760"/>
   <Type name="opls_246" class="opls_246" element="C" mass="12.011"/>
   <Type name="opls_247" class="opls_247" element="C" mass="12.011"/>
   <Type name="opls_248" class="opls_248" element="O" mass="15.9994"/>
@@ -3360,8 +3360,8 @@
   <Atom type="opls_237" charge="-0.76" sigma="0.325" epsilon="0.71128"/>
   <Atom type="opls_238" charge="-0.5" sigma="0.325" epsilon="0.71128"/>
   <Atom type="opls_239" charge="-0.14" sigma="0.325" epsilon="0.71128"/>
-  <Atom type="opls_240" charge="0.38" sigma="1.0" epsilon="0.0"/>
-  <Atom type="opls_241" charge="0.3" sigma="1.0" epsilon="0.0"/>
+  <Atom type="opls_240" charge="0.38" sigma="0.0" epsilon="0.0"/>
+  <Atom type="opls_241" charge="0.3" sigma="0.0" epsilon="0.0"/>
   <Atom type="opls_242" charge="0.02" sigma="0.35" epsilon="0.276144"/>
   <Atom type="opls_243" charge="-0.11" sigma="0.35" epsilon="0.276144"/>
   <Atom type="opls_244" charge="0.08" sigma="0.35" epsilon="0.276144"/>

--- a/foyer/forcefields/oplsaa.xml
+++ b/foyer/forcefields/oplsaa.xml
@@ -236,8 +236,8 @@
   <Type name="opls_234" class="opls_234" element="C" mass="12.011"/>
   <Type name="opls_235" class="C" element="C" mass="12.011" def="[C;X3]([O;X1])[N;X3]" desc="C=O in amide, dmf, peptide bond" overrides="opls_277" doi="10.1021/ja9621760"/>
   <Type name="opls_236" class="O" element="O" mass="15.9994" def="O[C;%opls_235]" desc="O: C=O in amide.   Acyl R on C in amide is neutral -" overrides="opls_278" doi="10.1021/ja9621760"/>
-  <Type name="opls_237" class="N" element="N" mass="14.0067" def="[N;X3](H)(H)([C;X3]([0;X1]))" desc="primary amide N, ex. carboxamide" doi="10.1021/ja9621760"/>
-  <Type name="opls_238" class="N" element="N" mass="14.0067" def="[N;X3](H)([C;X3]([O;X1])(C)" desc="secondary amide N, ex. NML" doi="10.1021/ja9621760"/>
+  <Type name="opls_237" class="N" element="N" mass="14.0067" def="[N;X3](H)(H)([C;X3]([O;X1]))" desc="primary amide N, ex. carboxamide" doi="10.1021/ja9621760"/>
+  <Type name="opls_238" class="N" element="N" mass="14.0067" def="[N;X3](H)([C;X3]([O;X1]))(C)" desc="secondary amide N, ex. NML" doi="10.1021/ja9621760"/>
   <Type name="opls_239" class="N" element="N" mass="14.0067" def="[N;X3]([!H])([!H])([!H])" desc="tertiary amide N" doi="10.1021/ja9621760"/>
   <Type name="opls_240" class="opls_240" element="H" mass="1.008"/>
   <Type name="opls_241" class="opls_241" element="H" mass="1.008"/>


### PR DESCRIPTION
### PR Summary:
Added definitions, descriptions, and doi for three atom types related to amides. These were added because I was running into issues using foyer to atomtype NMP and NMA for a small simulation.

All atom types are from Jorgensen et al OPLS-AA paper doi: 10.1021/ja9621760

The next step is to test these atomtypes with specific examples annd include overrides.

opls_237: describes the N in a primary amide such as carboxymide
opls_238: describes the N in a secondary amide such as NMA
opls_245: describes a secondary C bonded to an amide N such as in NMP

I also edited the description to opls_243 to specifically indicate that the carbon is primary.

opls_243: describes a primary C bonded to an amide N

This work-around allows me to atomtype NMP. Adding this should allow the modelling of proteins and any other molecules containing amide bonds. A more extensive search of the Jorgensen et al paper is required to ensure that all described amide parameters are supported.
### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
