### PR TITLE
Update atomtyper.py to use networkX 2.X methods

### DIFF
--- a/foyer/atomtyper.py
+++ b/foyer/atomtyper.py
@@ -26,7 +26,7 @@ def find_atomtypes(topology, forcefield, max_iter=10):
     subrules = dict()
     system_elements = {a.element.symbol for a in topology.atoms()}
     for key,val in rules.items():
-        atom = val.node[0]['atom']
+        atom = val.nodes[0]['atom']
         if len(list(atom.find_data('atom_symbol'))) == 1 and \
                     not list(atom.find_data('not_expression')):
             try:


### PR DESCRIPTION
### PR Summary:
Upgrading to networkX >= 2.4 removes the nx.Graph.node method, breaking
atomtyper.py.

NetworkX recently updated to 2.4 and the way we access nodes have been
removed: G.node –> use G.nodes. This was only present in `atomtyper.py`,
the rest of our node calls were using the new syntax.

Updating to handle the new syntax restores expected behavior, and all
unit tests pass.

### PR Checklist
------------
 - [x] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [x] Issue(s) raised/addressed?

Addresses issue #279 