### PR TITLE
Allow for user-specified typemap

### DIFF
--- a/foyer/tests/files/ethane-nodefs.xml
+++ b/foyer/tests/files/ethane-nodefs.xml
@@ -1,0 +1,21 @@
+ <ForceField>
+ <AtomTypes>
+    <Type name="opls_135" class="CT" element="C" mass="12.01100" desc="alkane CH3" doi="10.1021/ja9621760"/>
+    <Type name="opls_140" class="HC" element="H" mass="1.00800" desc="alkane H" doi="10.1021/ja9621760"/>
+ </AtomTypes>
+ <HarmonicBondForce>
+    <Bond class1="CT" class2="CT" length="0.1529" k="224262.4"/>
+    <Bond class1="CT" class2="HC" length="0.109" k="284512.0"/>
+ </HarmonicBondForce>
+ <HarmonicAngleForce>
+    <Angle class1="CT" class2="CT" class3="HC" angle="1.93207948196" k="313.8"/>
+    <Angle class1="HC" class2="CT" class3="HC" angle="1.88146493365" k="276.144"/>
+ </HarmonicAngleForce>
+ <RBTorsionForce>
+    <Proper class1="HC" class2="CT" class3="CT" class4="HC" c0="0.6276" c1="1.8828" c2="0.0" c3="-2.5104" c4="0.0" c5="0.0"/>
+ </RBTorsionForce>
+ <NonbondedForce coulomb14scale="0.5" lj14scale="0.5">
+     <Atom type="opls_135" charge="-0.18" sigma="0.35" epsilon="0.276144"/>
+     <Atom type="opls_140" charge="0.06" sigma="0.25" epsilon="0.12552"/>
+ </NonbondedForce>
+</ForceField>


### PR DESCRIPTION
### PR Summary:

Added a boolean option 'run_atomtyping' to the apply() function. If false, the atom typemap is generated from the input parmed structure (atom.type). This allows the user to specify their own atomtyping rather than using SMARTS strings. All forcefield parameters would still be stored in a ff.xml file and applied to the system by the remainder of apply().

E.g., of how I see this working: 
- Perform atomtyping in antechamber
- Read in correctly atomtyped .mol2 file  
- Load ff.xml file with GAFF parameters
- Apply FF. 

Since the typemap is extracted from the parmed structure input to apply(), the user could also manually edit atomtypes if necessary before supplying the structure to apply(). 

Open to modifications in approach if others have ideas/suggestions to implement similar functionality. 

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
