### PR TITLE
Switch entrypoints to functions that load classes

### DIFF
--- a/foyer/forcefields/forcefields.py
+++ b/foyer/forcefields/forcefields.py
@@ -27,5 +27,5 @@ def get_forcefield(name=None):
                 ' in path {}'.format(name, get_ff_path()))
     return Forcefield(ff_path)
 
-OPLSAA = get_forcefield(name='oplsaa')
-TRAPPE_UA = get_forcefield(name='trappe-ua')
+load_OPLSAA = get_forcefield(name='oplsaa')
+load_TRAPPE_UA = get_forcefield(name='trappe-ua')

--- a/foyer/forcefields/forcefields.py
+++ b/foyer/forcefields/forcefields.py
@@ -27,5 +27,14 @@ def get_forcefield(name=None):
                 ' in path {}'.format(name, get_ff_path()))
     return Forcefield(ff_path)
 
-load_OPLSAA = get_forcefield(name='oplsaa')
-load_TRAPPE_UA = get_forcefield(name='trappe-ua')
+
+def load_OPLSAA():
+    return get_forcefield(name='oplsaa')
+
+
+def load_TRAPPE_UA():
+    return get_forcefield(name='trappe-ua')
+
+
+load_OPLSAA = load_OPLSAA
+load_TRAPPE_UA = load_TRAPPE_UA

--- a/foyer/forcefields/forcefields.py
+++ b/foyer/forcefields/forcefields.py
@@ -34,7 +34,3 @@ def load_OPLSAA():
 
 def load_TRAPPE_UA():
     return get_forcefield(name='trappe-ua')
-
-
-load_OPLSAA = load_OPLSAA
-load_TRAPPE_UA = load_TRAPPE_UA

--- a/foyer/tests/test_plugin.py
+++ b/foyer/tests/test_plugin.py
@@ -6,9 +6,9 @@ def test_basic_import():
     assert 'forcefields' in dir(foyer)
 
 
-@pytest.mark.parametrize('ff_name', ['OPLSAA', 'TRAPPE_UA'])
-def test_forcefields_exist(ff_name):
-    ff_name in dir(foyer.forcefields)
+@pytest.mark.parametrize('ff_loader', ['load_OPLSAA', 'load_TRAPPE_UA'])
+def test_forcefields_exist(ff_loader):
+    assert ff_loader in dir(foyer.forcefields)
 
 
 def test_load_forcefield():

--- a/foyer/tests/test_plugin.py
+++ b/foyer/tests/test_plugin.py
@@ -6,9 +6,11 @@ def test_basic_import():
     assert 'forcefields' in dir(foyer)
 
 
-@pytest.mark.parametrize('ff_loader', ['load_OPLSAA', 'load_TRAPPE_UA'])
-def test_forcefields_exist(ff_loader):
-    assert ff_loader in dir(foyer.forcefields)
+def test_loading_forcefields():
+    #funcs = [func for func in dir(foyer.forcefields) if 'load' in func and '__' not in func]
+    for func in dir(foyer.forcefields):
+        if 'load_' in func and '__' not in func:
+            eval('foyer.forcefields.' + func)()
 
 
 def test_load_forcefield():

--- a/foyer/tests/test_validator.py
+++ b/foyer/tests/test_validator.py
@@ -17,7 +17,7 @@ ERRORS = {'validationerror': (ValidationError, MultipleValidationError),
 }
 
 FF_DIR = resource_filename('foyer', 'forcefields')
-FORCEFIELDS = glob.glob(os.path.join(FF_DIR, '*.xml'))
+FORCEFIELDS = glob.glob(os.path.join(FF_DIR, 'xml/*.xml'))
 
 
 @pytest.mark.parametrize('ff_file', XMLS)

--- a/setup.py
+++ b/setup.py
@@ -99,8 +99,8 @@ setup(
                             ]},
     entry_points={
         'foyer.forcefields':[
-            "OPLSAA = foyer.forcefields.forcefields:OPLSAA",
-            "TRAPPE_UA = foyer.forcefields.forcefields:TRAPPE_UA",
+            "load_OPLSAA = foyer.forcefields.forcefields:load_OPLSAA",
+            "load_TRAPPE_UA = foyer.forcefields.forcefields:load_TRAPPE_UA",
         ]
     },
     package_dir={'foyer': 'foyer'},


### PR DESCRIPTION
### PR Summary:
Small change post-#282 per suggestions of @uppittu11 and @ahy3nz https://github.com/mosdef-hub/foyer/pull/282#issuecomment-547144491 https://github.com/mosdef-hub/forcefield_perfluoroethers/pull/4/files#r339807274
Instead of the entrypoint being an instance of the force field, it's a function that grabs it. This cleans up the import such that the user more discretely instantiates the object. It also prevents the loading from happening upon `import foyer` and should save some time on imports. A quick local check saved ~0.3 seconds, no promises this is accurate.

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
