### PR TITLE
Add initial attempt at a plugin detector.

### DIFF
--- a/foyer/__init__.py
+++ b/foyer/__init__.py
@@ -1,3 +1,4 @@
 from foyer.forcefield import Forcefield
 from foyer.forcefields import forcefields
 from foyer.version import version
+from foyer.plugins import collect_plugins

--- a/foyer/plugins.py
+++ b/foyer/plugins.py
@@ -1,0 +1,39 @@
+import foyer
+import glob
+
+def collect_plugins(plugin_names=None):
+    """
+    Detects which plugins are installed
+
+    Arguments
+    ---------
+    plugin_names: list, default=None
+        A list of non-standard plugin names (strings) to additionally
+        check for.
+    """
+
+    plugin_funcs = [func for func in dir(foyer.forcefields)
+                    if "load" in func and "__" not in func]
+
+    if plugin_names:
+        plugin_funcs += plugin_names
+
+    plugins = dict()
+    for plugin_func in plugin_funcs:
+        plugin_loader_func = eval("foyer.forcefields.{}".format(plugin_func))
+        # Assumes all plugins are named "load_{plugin_name}"
+        plugin_name = "_".join(plugin_func.split("_")[1:])
+        # TODO: plugin_version = get_version_info
+        plugin_dir = eval("foyer.forcefields.{}.__globals__['__file__']".format(plugin_func))
+        # TODO: plugin_xml_path = get_xml_path
+        # This assumes that plugin directory tree is consistent.
+        # Does not consider versioned FFs.
+        plugin_xml_path = glob.glob("{}/xml/*xml".format(plugin_dir))
+
+        plugin = {plugin_name : {"version"       : None,
+                                 "load_function" : plugin_loader_func,
+                                 "xml_path"      : plugin_xml_path
+                                 }}
+        plugins.update(plugin)
+
+    return plugins


### PR DESCRIPTION
Here is an attempt at a writing a plugin detector (#290). See `foyer.plugins:collect_plugins()`

Functions named `foyer.forcefields.load_{plugin_name}` are detected as plugins, but there is also a `plugin_names` argument to supply a list of plugin function names that don't fit that mold. The `version`, `xml_file`, and `load_function are collected into a `dict` and returned. 

I still don't know how to get the `version`. Maybe we could add it as an attribute of the plugin forcefield object when we load it up:

```python3
def load_OPLSAA():
    ff = get_forcefield(name='oplsaa')
    ff.version = 0.0.1
    return ff
```