### PR TITLE
`_check_angles` bug fix

### DIFF
--- a/foyer/forcefield.py
+++ b/foyer/forcefield.py
@@ -263,12 +263,6 @@ def _check_bonds(data, structure, assert_bond_params):
 
 def _check_angles(data, structure, verbose, assert_angle_params):
     """Check if all angles were found and parametrized."""
-    if data.angles and (len(data.angles) != len(structure.angles)):
-        msg = ("Parameters have not been assigned to all angles. Total "
-               "system angles: {}, Parameterized angles: {}"
-               "".format(len(data.angles), len(structure.angles)))
-        _error_or_warn(assert_angle_params, msg)
-
     if verbose:
         for omm_ids in data.angles:
             missing_angle = True
@@ -279,6 +273,13 @@ def _check_angles(data, structure, verbose, assert_angle_params):
             if missing_angle:
                 print("Missing angle with ids {} and types {}.".format(
                     omm_ids, [structure.atoms[idx].type for idx in omm_ids]))
+
+    if data.angles and (len(data.angles) != len(structure.angles)):
+        msg = ("Parameters have not been assigned to all angles. Total "
+               "system angles: {}, Parameterized angles: {}"
+               "".format(len(data.angles), len(structure.angles)))
+        _error_or_warn(assert_angle_params, msg)
+
 
 
 def _check_dihedrals(data, structure, verbose,


### PR DESCRIPTION
### PR Summary:
Reorder the codes for `_check_angles`. Right now, even if `verbose=True`, the corresponding block of code will not be excuted because of the `_error_or_warn` line right before it. 
### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
