### PR TITLE
Add version attribute to force fields

### DIFF
--- a/foyer/forcefield.py
+++ b/foyer/forcefield.py
@@ -343,6 +343,7 @@ class Forcefield(app.ForceField):
         self._included_forcefields = dict()
         self.non_element_types = dict()
         self._version = None
+        self._name = None
 
         all_files_to_load = []
         if forcefield_files is not None:
@@ -372,8 +373,10 @@ class Forcefield(app.ForceField):
 
         if isinstance(forcefield_files, str):
             self._version = self._parse_version_number(forcefield_files)
+            self._name = self._parse_name(forcefield_files)
         elif isinstance(forcefield_files, list):
             self._version = [self._parse_version_number(f) for f in forcefield_files]
+            self._name = [self._parse_name(f) for f in forcefield_files]
 
         self.parser = smarts.SMARTS(self.non_element_types)
         self._SystemData = self._SystemData()
@@ -381,6 +384,10 @@ class Forcefield(app.ForceField):
     @property
     def version(self):
         return self._version
+
+    @property
+    def name(self):
+        return self._name
 
     @property
     def included_forcefields(self):
@@ -402,6 +409,15 @@ class Forcefield(app.ForceField):
             root = tree.getroot()
             try:
                 return root.attrib['version']
+            except KeyError:
+                return None
+
+    def _parse_name(self, forcefield_file):
+        with open(forcefield_file, 'r') as f:
+            tree = ET.parse(f)
+            root = tree.getroot()
+            try:
+                return root.attrib['name']
             except KeyError:
                 return None
 

--- a/foyer/forcefield.py
+++ b/foyer/forcefield.py
@@ -370,19 +370,12 @@ class Forcefield(app.ForceField):
             for ff_file_name in preprocessed_files:
                 os.remove(ff_file_name)
         self._version = 'foobar'
-        if len(forcefield_files) == 1:
-            with open(forcefield_files[0], 'r') as f:
+        if isinstance(forcefield_files, str):
+            with open(forcefield_files, 'r') as f:
                 tree = ET.parse(f)
                 root = tree.getroot()
                 if root.attrib['version']:
-                    print('foooo')
                     self._version = root.attrib['version']
-                    print('version is' + self._version)
-                f.close()
-                print('version is' + self._version)
-
-            print('version is' + self._version)
-        print('version is' + self._version)
         self.parser = smarts.SMARTS(self.non_element_types)
         self._SystemData = self._SystemData()
 

--- a/foyer/forcefield.py
+++ b/foyer/forcefield.py
@@ -369,15 +369,12 @@ class Forcefield(app.ForceField):
         finally:
             for ff_file_name in preprocessed_files:
                 os.remove(ff_file_name)
-        self._version = 'foobar'
+
         if isinstance(forcefield_files, str):
-            with open(forcefield_files, 'r') as f:
-                tree = ET.parse(f)
-                root = tree.getroot()
-                try: 
-                    self._version = root.attrib['version']
-                except KeyError:
-                    pass
+            self._version = self._parse_version_number(forcefield_files)
+        elif isinstance(forcefield_files, list):
+            self._version = [self._parse_version_number(f) for f in forcefield_files]
+
         self.parser = smarts.SMARTS(self.non_element_types)
         self._SystemData = self._SystemData()
 
@@ -398,6 +395,15 @@ class Forcefield(app.ForceField):
             basename, _ = os.path.splitext(ff_file)
             self._included_forcefields[basename] = ff_filepath
         return self._included_forcefields
+
+    def _parse_version_number(self, forcefield_file):
+        with open(forcefield_file, 'r') as f:
+            tree = ET.parse(f)
+            root = tree.getroot()
+            try:
+                return root.attrib['version']
+            except KeyError:
+                return None
 
     def _create_element(self, element, mass):
         if not isinstance(element, elem.Element):

--- a/foyer/forcefield.py
+++ b/foyer/forcefield.py
@@ -410,6 +410,9 @@ class Forcefield(app.ForceField):
             try:
                 return root.attrib['version']
             except KeyError:
+                warnings.warn(
+                    'No force field version number found in force field XML file.'
+                )
                 return None
 
     def _parse_name(self, forcefield_file):
@@ -419,6 +422,9 @@ class Forcefield(app.ForceField):
             try:
                 return root.attrib['name']
             except KeyError:
+                warnings.warn(
+                    'No force field name found in force field XML file.'
+                )
                 return None
 
     def _create_element(self, element, mass):

--- a/foyer/forcefield.py
+++ b/foyer/forcefield.py
@@ -374,8 +374,10 @@ class Forcefield(app.ForceField):
             with open(forcefield_files, 'r') as f:
                 tree = ET.parse(f)
                 root = tree.getroot()
-                if root.attrib['version']:
+                try: 
                     self._version = root.attrib['version']
+                except KeyError:
+                    pass
         self.parser = smarts.SMARTS(self.non_element_types)
         self._SystemData = self._SystemData()
 

--- a/foyer/forcefield.py
+++ b/foyer/forcefield.py
@@ -342,6 +342,7 @@ class Forcefield(app.ForceField):
         self.atomTypeElements = dict()
         self._included_forcefields = dict()
         self.non_element_types = dict()
+        self._version = None
 
         all_files_to_load = []
         if forcefield_files is not None:
@@ -368,8 +369,26 @@ class Forcefield(app.ForceField):
         finally:
             for ff_file_name in preprocessed_files:
                 os.remove(ff_file_name)
+        self._version = 'foobar'
+        if len(forcefield_files) == 1:
+            with open(forcefield_files[0], 'r') as f:
+                tree = ET.parse(f)
+                root = tree.getroot()
+                if root.attrib['version']:
+                    print('foooo')
+                    self._version = root.attrib['version']
+                    print('version is' + self._version)
+                f.close()
+                print('version is' + self._version)
+
+            print('version is' + self._version)
+        print('version is' + self._version)
         self.parser = smarts.SMARTS(self.non_element_types)
         self._SystemData = self._SystemData()
+
+    @property
+    def version(self):
+        return self._version
 
     @property
     def included_forcefields(self):

--- a/foyer/forcefields/ff.xsd
+++ b/foyer/forcefields/ff.xsd
@@ -255,6 +255,7 @@
         <xs:element ref="CustomTorsionForce" minOccurs="0"/>
         <xs:element ref="NonbondedForce" minOccurs="0"/>
       </xs:all>
+      <xs:attribute type="xs:string" name="version" use="optional"/>
     </xs:complexType>
     <xs:key name="atomtype_name_key">
       <xs:selector xpath="AtomTypes/Type" />

--- a/foyer/forcefields/ff.xsd
+++ b/foyer/forcefields/ff.xsd
@@ -256,6 +256,7 @@
         <xs:element ref="NonbondedForce" minOccurs="0"/>
       </xs:all>
       <xs:attribute type="xs:string" name="version" use="optional"/>
+      <xs:attribute type="xs:string" name="name" use="optional"/>
     </xs:complexType>
     <xs:key name="atomtype_name_key">
       <xs:selector xpath="AtomTypes/Type" />

--- a/foyer/tests/files/lj.xml
+++ b/foyer/tests/files/lj.xml
@@ -1,4 +1,4 @@
-<ForceField version="0.4.1">
+<ForceField version="0.4.1" name="LJ">
  <AtomTypes>
    <Type name="LJ" class="" element="_LJ" mass="1.0" def="[_LJ]" desc="Generic LJ particle"/>
  </AtomTypes>

--- a/foyer/tests/files/lj.xml
+++ b/foyer/tests/files/lj.xml
@@ -1,0 +1,8 @@
+<ForceField version="0.4.1">
+ <AtomTypes>
+   <Type name="LJ" class="" element="_LJ" mass="1.0" def="[_LJ]" desc="Generic LJ particle"/>
+ </AtomTypes>
+ <NonbondedForce coulomb14scale="0.5" lj14scale="0.5">
+  <Atom type="LJ" charge="0" sigma="1.0" epsilon="1.0"/>
+ </NonbondedForce>
+</ForceField>

--- a/foyer/tests/files/lj2.xml
+++ b/foyer/tests/files/lj2.xml
@@ -1,0 +1,8 @@
+<ForceField version="4.8.2">
+ <AtomTypes>
+   <Type name="JL" class="" element="_JL" mass="1.0" def="[_JL]" desc="Generic JL particle"/>
+ </AtomTypes>
+ <NonbondedForce coulomb14scale="0.5" lj14scale="0.5">
+  <Atom type="JL" charge="0" sigma="1.0" epsilon="1.0"/>
+ </NonbondedForce>
+</ForceField>

--- a/foyer/tests/files/lj2.xml
+++ b/foyer/tests/files/lj2.xml
@@ -1,4 +1,4 @@
-<ForceField version="4.8.2">
+<ForceField version="4.8.2" name="JL">
  <AtomTypes>
    <Type name="JL" class="" element="_JL" mass="1.0" def="[_JL]" desc="Generic JL particle"/>
  </AtomTypes>

--- a/foyer/tests/test_forcefield.py
+++ b/foyer/tests/test_forcefield.py
@@ -504,3 +504,7 @@ def test_write_xml_overrides():
         elif attributes['name'] == 'opls_146':
             assert attributes['overrides'] == 'opls_144'
             assert str(item.xpath('comment()')) == '[<!--Note: original overrides="opls_144"-->]'
+
+def test_load_version_number():
+    lj_ff = Forcefield(get_fn('lj.xml'))
+    assert lj_ff.version == '0.4.1'

--- a/foyer/tests/test_forcefield.py
+++ b/foyer/tests/test_forcefield.py
@@ -508,6 +508,8 @@ def test_write_xml_overrides():
 def test_load_version_number():
     lj_ff = Forcefield(get_fn('lj.xml'))
     assert lj_ff.version == '0.4.1'
+    assert lj_ff.name == 'LJ'
 
     lj_ff = Forcefield(forcefield_files=[get_fn('lj.xml'), get_fn('lj2.xml')])
     assert lj_ff.version == ['0.4.1', '4.8.2']
+    assert lj_ff.name == ['LJ', 'JL']

--- a/foyer/tests/test_forcefield.py
+++ b/foyer/tests/test_forcefield.py
@@ -508,3 +508,6 @@ def test_write_xml_overrides():
 def test_load_version_number():
     lj_ff = Forcefield(get_fn('lj.xml'))
     assert lj_ff.version == '0.4.1'
+
+    lj_ff = Forcefield(forcefield_files=[get_fn('lj.xml'), get_fn('lj2.xml')])
+    assert lj_ff.version == ['0.4.1', '4.8.2']

--- a/foyer/tests/test_forcefield.py
+++ b/foyer/tests/test_forcefield.py
@@ -505,7 +505,7 @@ def test_write_xml_overrides():
             assert attributes['overrides'] == 'opls_144'
             assert str(item.xpath('comment()')) == '[<!--Note: original overrides="opls_144"-->]'
 
-def test_load_version_number():
+def test_load_metadata():
     lj_ff = Forcefield(get_fn('lj.xml'))
     assert lj_ff.version == '0.4.1'
     assert lj_ff.name == 'LJ'


### PR DESCRIPTION
### PR Summary:

Fixes  #187, would be useful in  #290 

* Adds `version` as an attribute of the `ForceField` element in the XML schema
* Adds `version` as an attribute to the `Forcefield` class
* Adds a simple test via reading a toy XML file and asserting the above two `version`s are equal

This is not done elegantly right now; 99% of the XML loading is done by OpenMM, so I had to do this after the fact and only dealing with the case of passing a single XML, which is all I believe we do right now. I'm not sure what the target for this PR should be, but I think we should soon have a bigger discussion about how we want to handle multiple XML files. The OpenMM use case is basically `Forcefield('protein_model.xml', 'water_model.xml')`, i.e. there is a clean interface between constituents and not any expected overlap between the two. This doesn't cleanly map on to our use cases, I don't think. Related to #297 #262 #149

If this seems reasonable I can do the same for names (#153), here or in another PR. Requesting a few specific reviewers since I have discussed this with many people over the past year or two (but only gotten to it now 🤕)

### PR Checklist
------------
 - [x] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [x] Issue(s) raised/addressed?
