### PR TITLE
Fix Travis Build Erros

### DIFF
--- a/devtools/travis-ci/install_conda.sh
+++ b/devtools/travis-ci/install_conda.sh
@@ -4,7 +4,7 @@ if [[ "$TRAVIS_OS_NAME" == "osx" ]];   then MINICONDA=Miniconda3-latest-MacOSX-x
 if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then MINICONDA=Miniconda3-latest-Linux-x86_64.sh;  fi
 
 MINICONDA_MD5=$(curl -s https://repo.continuum.io/miniconda/ | grep -A3 $MINICONDA | sed -n '4p' | sed -n 's/ *<td>\(.*\)<\/td> */\1/p')
-wget https://repo.continuum.io/miniconda/$MINICONDA
+curl -O https://repo.continuum.io/miniconda/$MINICONDA
 if [[ $MINICONDA_MD5 != $(md5sum $MINICONDA | cut -d ' ' -f 1) ]]; then
     echo "Miniconda MD5 mismatch"
     exit 1


### PR DESCRIPTION
This is a very minor change to download `Minconda` using `curl` rather than `wget`. The errrored builds we are getting is due to `wget` and `openssl` paths. Using `curl` resolves this.

Travis build for this branch can be tracked [here](https://travis-ci.org/umesh-timalsina/foyer/jobs/616827616).