### PR TITLE
Add temporary fix for periodic dihedrals

### DIFF
--- a/foyer/forcefield.py
+++ b/foyer/forcefield.py
@@ -310,22 +310,32 @@ def _check_dihedrals(data, structure, verbose,
     if verbose:
         for omm_ids in data.propers:
             missing_dihedral = True
-            for pmd_proper in structure.rb_torsions:
+            for pmd_proper in (structure.rb_torsions + proper_dihedrals):
                 pmd_ids = (pmd_proper.atom1.idx, pmd_proper.atom2.idx, pmd_proper.atom3.idx, pmd_proper.atom4.idx)
                 if pmd_ids == omm_ids:
                     missing_dihedral = False
             if missing_dihedral:
-                print('missing improper with ids {}'.format(pmd_ids))
-
+                print('missing proper with ids {}'.format(pmd_ids))
     if data.propers and len(data.propers) != \
             len(proper_dihedrals) + len(structure.rb_torsions):
-        msg = ("Parameters have not been assigned to all proper dihedrals. "
-               "Total system dihedrals: {}, Parameterized dihedrals: {}. "
-               "Note that if your system contains torsions of Ryckaert-"
-               "Bellemans functional form, all of these torsions are "
-               "processed as propers.".format(len(data.propers),
-                                              len(proper_dihedrals) + len(structure.rb_torsions)))
-        _error_or_warn(assert_dihedral_params, msg)
+        if data.propers and len(data.propers) < \
+                len(proper_dihedrals) + len(structure.rb_torsions):
+            msg = ("Parameters have been assigned to all proper dihedrals.  "
+                   "However, there are more parameterized dihedrals ({}) "
+                   "than total system dihedrals ({}).  "
+                   "This may be due to having multiple periodic dihedrals "
+                   "for a single system dihedral.".format(len(proper_dihedrals) +
+                                                  len(structure.rb_torsions),
+                                                  len(data.propers)))
+            warnings.warn(msg)
+        else:
+            msg = ("Parameters have not been assigned to all proper dihedrals. "
+                   "Total system dihedrals: {}, Parameterized dihedrals: {}. "
+                   "Note that if your system contains torsions of Ryckaert-"
+                   "Bellemans functional form, all of these torsions are "
+                   "processed as propers.".format(len(data.propers),
+                                                  len(proper_dihedrals) + len(structure.rb_torsions)))
+            _error_or_warn(assert_dihedral_params, msg)
 
     improper_dihedrals = [dihedral for dihedral in structure.dihedrals
                           if dihedral.improper]


### PR DESCRIPTION
### PR Summary:
Addressing issues raised in #323 and #326.  Two changes in `forcefield.py`:
- when `verbose=True`, compare the openmm dihedrals to both parmed rb_torsions and dihedrals.  This allows a system with periodic dihedrals to be compared with `structure.dihedrals`.
- Raise separate errors/warnings for when openmm dihedrals != parmed dihedrals vs openmm dihedrals < parmed dihedrals.  The motivation for this is in the case of #323, there were more parmed dihedrals than openmm dihedrals because a single dihedral type contained multiple dihedrals.  I don't think this should raise an error, so in this case I raise a warning and a separate message instead.

This is very much a temporary fix, and I expect dihedrals will be handled much better with the new backend.  This is also just an idea, so feel free to tell me if it's a bad one.

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
