### PR TITLE
fixed error in verbose mode for missing dihedrals

### DIFF
--- a/foyer/forcefield.py
+++ b/foyer/forcefield.py
@@ -323,14 +323,25 @@ def _check_dihedrals(data, structure, verbose,
                         omm_ids, [structure.atoms[idx].type for idx in omm_ids]))
 
     if data.propers and len(data.propers) != \
-            len(proper_dihedrals) + len(structure.rb_torsions):
-        msg = ("Parameters have not been assigned to all proper dihedrals. "
-               "Total system dihedrals: {}, Parameterized dihedrals: {}. "
-               "Note that if your system contains torsions of Ryckaert-"
-               "Bellemans functional form, all of these torsions are "
-               "processed as propers.".format(len(data.propers),
-                                              len(proper_dihedrals) + len(structure.rb_torsions)))
-        _error_or_warn(assert_dihedral_params, msg)
+                len(proper_dihedrals) + len(structure.rb_torsions):
+            if data.propers and len(data.propers) < \
+                    len(proper_dihedrals) + len(structure.rb_torsions):
+                msg = ("Parameters have been assigned to all proper dihedrals.  "
+                       "However, there are more parameterized dihedrals ({}) "
+                       "than total system dihedrals ({}).  "
+                       "This may be due to having multiple periodic dihedrals "
+                       "for a single system dihedral.".format(len(proper_dihedrals) +
+                                                      len(structure.rb_torsions),
+                                                      len(data.propers)))
+                warnings.warn(msg)
+            else:
+                msg = ("Parameters have not been assigned to all proper dihedrals. "
+                       "Total system dihedrals: {}, Parameterized dihedrals: {}. "
+                       "Note that if your system contains torsions of Ryckaert-"
+                       "Bellemans functional form, all of these torsions are "
+                       "processed as propers.".format(len(data.propers),
+                                                      len(proper_dihedrals) + len(structure.rb_torsions)))
+                _error_or_warn(assert_dihedral_params, msg)
 
     improper_dihedrals = [dihedral for dihedral in structure.dihedrals
                           if dihedral.improper]

--- a/foyer/forcefield.py
+++ b/foyer/forcefield.py
@@ -310,12 +310,17 @@ def _check_dihedrals(data, structure, verbose,
     if verbose:
         for omm_ids in data.propers:
             missing_dihedral = True
+            for pmd_proper in proper_dihedrals:
+                pmd_ids = (pmd_proper.atom1.idx, pmd_proper.atom2.idx, pmd_proper.atom3.idx, pmd_proper.atom4.idx)
+                if pmd_ids == omm_ids:
+                    missing_dihedral = False
             for pmd_proper in structure.rb_torsions:
                 pmd_ids = (pmd_proper.atom1.idx, pmd_proper.atom2.idx, pmd_proper.atom3.idx, pmd_proper.atom4.idx)
                 if pmd_ids == omm_ids:
                     missing_dihedral = False
             if missing_dihedral:
-                print('missing improper with ids {}'.format(pmd_ids))
+                print("Missing dihedral with ids {} and types {}.".format(
+                        omm_ids, [structure.atoms[idx].type for idx in omm_ids]))
 
     if data.propers and len(data.propers) != \
             len(proper_dihedrals) + len(structure.rb_torsions):


### PR DESCRIPTION
### PR Summary:

This is relate to a few recent issues posted.

https://github.com/mosdef-hub/foyer/issues/326
https://github.com/mosdef-hub/foyer/issues/323

1) There was a coding issue in the part of the code that would write out a missing RB dihedral when in verbose mode (undefined parameters referenced).  Also, only ids were being output, not types (inconsistent with, e.g., how angles were outputted).   The coding and formatting issues have been addressed. 

2) Even when fixing that coding/formatting issues, the code only checked the RB torsions. So, when I was testing periodic torsions, it alerted that all dihedrals were missing.    This bit now has two loops, first looping over proper_dihedrals and then rb_torsions in parmed structure. 



### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
