### PR TITLE
Pin lark parser until fix

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@ openmm
 mbuild
 parmed
 networkx >=2.0
-lark-parser
+lark-parser <=0.8.5
 requests
 lxml
 pytest >=3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 openmm
 parmed
 networkx >=2.0
-lark-parser
+lark-parser <=0.8.5
 requests
 lxml


### PR DESCRIPTION
### PR Summary:

`lark-parser 0.8.6` was [released](https://github.com/lark-parser/lark/releases) earlier today. It introduces some breaking changes for foyer atom typing. This PR pins `lark-parser` to `<=0.8.5` until we can sort out the problem.