### PR TITLE
Add warning for non-zero charge structure

### DIFF
--- a/foyer/forcefield.py
+++ b/foyer/forcefield.py
@@ -642,6 +642,11 @@ class Forcefield(app.ForceField):
         # if self.name == 'oplsaa':
         structure.combining_rule = combining_rule
 
+        total_charge = sum([atom.charge for atom in structure.atoms])
+        if not np.allclose(total_charge, 0):
+            warnings.warn("Parametrized structure has non-zero charge."
+                "Structure's total charge: {}".format(total_charge))
+
         return structure
 
     def createSystem(self, topology, nonbondedMethod=NoCutoff,

--- a/foyer/tests/test_forcefield.py
+++ b/foyer/tests/test_forcefield.py
@@ -399,6 +399,13 @@ def test_apply_subfuncs():
     for ang1, ang2 in zip(ethane.angles, ethane2.angles):
         assert ang1.type == ang2.type
 
+def test_non_zero_charge():
+    import mbuild as mb
+    compound = mb.load('C1=CC=C2C(=C1)C(C3=CC=CC=C3O2)C(=O)O', smiles=True)
+    oplsaa = Forcefield(name='oplsaa')
+    with pytest.warns(UserWarning):
+        oplsaa.apply(compound, assert_dihedral_params=False)
+
 @pytest.mark.parametrize("filename", ['ethane.mol2', 'benzene.mol2'])
 def test_write_xml(filename):
     mol = pmd.load_file(get_fn(filename), structure=True)


### PR DESCRIPTION
Relate to #336. Add a warning if a typed structure has non-zero charge. 'np.allclose()' is used instead of '==' to check for 0 equivalence so since some system may have insignificant non-zero net charge (like 1e-16).

### PR Summary:

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [x] Issue(s) raised/addressed?
