### PR TITLE
find_data in lark

### DIFF
--- a/foyer/smarts_graph.py
+++ b/foyer/smarts_graph.py
@@ -58,7 +58,7 @@ class SMARTSGraph(nx.Graph):
 
     def _add_nodes(self):
         """Add all atoms in the SMARTS string as nodes in the graph."""
-        for n, atom in enumerate(self.ast.find_data('atom')):
+        for n, atom in enumerate([x for x in self.ast.iter_subtrees_topdown() if x.data == 'atom']):
             self.add_node(n, atom=atom)
             self._atom_indices[id(atom)] = n
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@ openmm
 mbuild
 parmed
 networkx >=2.0
-lark-parser <=0.8.5
+lark-parser
 requests
 lxml
 pytest >=3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 openmm
 parmed
 networkx >=2.0
-lark-parser <=0.8.5
+lark-parser 
 requests
 lxml


### PR DESCRIPTION
self.ast.find_data('atom') destroys the original order of atoms in a SMARTSGraph. Since later on, the first atom is used for atom-typing, it was causing an error. The following keeps the order:
[x for x in self.ast.iter_subtrees_topdown() if x.data == 'atom']

### PR Summary:

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
