### PR TITLE
Entrypoints conda

### DIFF
--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -11,13 +11,11 @@ build:
     - python
   number: {{ environ.get('GIT_DESCRIBE_NUMBER', 0)}}
   script: python setup.py install --single-version-externally-managed --record record.txt
-  entry_points:
-          - load_OPLSAA = foyer.forcefields.forcefields:load_OPLSAA
-          - load_TRAPPE_UA = foyer.forcefields.forcefields:load_TRAPPE_UA
 
 requirements:
   build:
     - python
+    - setuptools
 
   run:
     - parmed

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -11,6 +11,9 @@ build:
     - python
   number: {{ environ.get('GIT_DESCRIBE_NUMBER', 0)}}
   script: python setup.py install --single-version-externally-managed --record record.txt
+  entry_points:
+          - load_OPLSAA = foyer.forcefields.forcefields:load_OPLSAA
+          - load_TRAPPE_UA = foyer.forcefields.forcefields:load_TRAPPE_UA
 
 requirements:
   build:

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -12,9 +12,6 @@ build:
   preserve_egg_dir: True
   number: {{ environ.get('GIT_DESCRIBE_NUMBER', 0)}}
   script: python setup.py install --single-version-externally-managed --record record.txt
-  entry_points:
-          - load_OPLSAA = foyer.forcefields.forcefields:load_OPLSAA
-          - load_TRAPPE_UA = foyer.forcefields.forcefields:load_TRAPPE_UA
 
 requirements:
   build:

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -12,11 +12,13 @@ build:
   preserve_egg_dir: True
   number: {{ environ.get('GIT_DESCRIBE_NUMBER', 0)}}
   script: python setup.py install --single-version-externally-managed --record record.txt
+  entry_points:
+          - load_OPLSAA = foyer.forcefields.forcefields:load_OPLSAA
+          - load_TRAPPE_UA = foyer.forcefields.forcefields:load_TRAPPE_UA
 
 requirements:
   build:
     - python
-    - setuptools
 
   run:
     - parmed

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -16,6 +16,7 @@ build:
 requirements:
   build:
     - python
+    - setuptools
 
   run:
     - parmed

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -9,6 +9,7 @@ build:
   noarch: python
   ignore_run_exports:
     - python
+  preserve_egg_dir: True
   number: {{ environ.get('GIT_DESCRIBE_NUMBER', 0)}}
   script: python setup.py install --single-version-externally-managed --record record.txt
 
@@ -24,6 +25,7 @@ requirements:
     - lark-parser
     - requests
     - lxml
+    - setuptools
 
 test:
   requires:


### PR DESCRIPTION
### PR Summary:
To ensure that we have our plugins supported properly when installed
from conda, it appears that a few options are necessary to ensure that
is the case.

For the case of setuptools entry_points, the conda-build documentation
recommends that we do include the build option: preserve_egg_dir

https://docs.conda.io/projects/conda-build/en/latest/user-guide/recipes/build-without-recipe.html#preserve-egg-directory

Setuptools are also now build and runtime dependencies.

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
