### PR TITLE
Boil down graph

### DIFF
--- a/foyer/atomtyper.py
+++ b/foyer/atomtyper.py
@@ -154,40 +154,22 @@ def _iterate_rules(rules, topology, typemap, max_iter):
 
     """
 
-    if isinstance(topology, parmed.Structure):
-        for _ in range(max_iter):
-            max_iter -= 1
-            found_something = False
-            for rule in rules.values():
-                for match_index in rule.find_matches(topology, typemap):
-                    atom = typemap[match_index]
-                    # This conditional is not strictly necessary, but it prevents
-                    # redundant set addition on later iterations
-                    if rule.name not in atom['whitelist']:
-                        atom['whitelist'].add(rule.name)
-                        atom['blacklist'] |= rule.overrides
-                        found_something = True
-            if not found_something:
-                break
-        else:
-            warn("Reached maximum iterations. Something probably went wrong.")
-    elif isinstance(topology, gmso.Topology):
-        for _ in range(max_iter):
-            max_iter -= 1
-            found_something = False
-            for rule in rules.values():
-                for match_index in rule.find_matches(topology, typemap):
-                    atom = typemap[match_index]
-                    # This conditional is not strictly necessary, but it prevents
-                    # redundant set addition on later iterations
-                    if rule.name not in atom['whitelist']:
-                        atom['whitelist'].add(rule.name)
-                        atom['blacklist'] |= rule.overrides
-                        found_something = True
-            if not found_something:
-                break
-        else:
-            warn("Reached maximum iterations. Something probably went wrong.")
+    for _ in range(max_iter):
+        max_iter -= 1
+        found_something = False
+        for rule in rules.values():
+            for match_index in rule.find_matches(topology, typemap):
+                atom = typemap[match_index]
+                # This conditional is not strictly necessary, but it prevents
+                # redundant set addition on later iterations
+                if rule.name not in atom['whitelist']:
+                    atom['whitelist'].add(rule.name)
+                    atom['blacklist'] |= rule.overrides
+                    found_something = True
+        if not found_something:
+            break
+    else:
+        warn("Reached maximum iterations. Something probably went wrong.")
     return typemap
 
 def _resolve_atomtypes(structure, typemap):

--- a/foyer/smarts_graph.py
+++ b/foyer/smarts_graph.py
@@ -95,8 +95,9 @@ class SMARTSGraph(nx.Graph):
     def _node_match(self, host, pattern):
         """ Determine if two graph nodes are equal """
         atom_expr = pattern['atom'].children[0]
-        atom = host['atom']
-        return self._atom_expr_matches(atom_expr, atom)
+        #atom = host['atom']
+        #return self._atom_expr_matches(atom_expr, atom)
+        return self._atom_expr_matches(atom_expr, host)
 
     def _atom_expr_matches(self, atom_expr, atom):
         """ Helper function for evaluating SMARTS string expressions """
@@ -120,7 +121,7 @@ class SMARTSGraph(nx.Graph):
     @staticmethod
     def _atom_id_matches(atom_id, atom, typemap):
         """ Helper func for comparing atomic indices, symbols, neighbors, rings """
-        atomic_num = atom.element
+        atomic_num = atom['atomic_number']
         if atom_id.data == 'atomic_num':
             return atomic_num == int(atom_id.children[0])
         elif atom_id.data == 'atom_symbol':
@@ -128,22 +129,22 @@ class SMARTSGraph(nx.Graph):
                 return True
             elif str(atom_id.children[0]).startswith('_'):
                 # Store non-element elements in .name
-                return atom.name == str(atom_id.children[0])
+                return atom['name'] == str(atom_id.children[0])
             else:
                 return atomic_num == pt.AtomicNum[str(atom_id.children[0])]
         elif atom_id.data == 'has_label':
             label = atom_id.children[0][1:]  # Strip the % sign from the beginning.
-            return label in typemap[atom.idx]['whitelist']
+            return label in typemap[atom['idx']]['whitelist']
         elif atom_id.data == 'neighbor_count':
-            return len(atom.bond_partners) == int(atom_id.children[0])
+            return atom['n_bond_partners'] == int(atom_id.children[0])
         elif atom_id.data == 'ring_size':
             cycle_len = int(atom_id.children[0])
-            for cycle in typemap[atom.idx]['cycles']:
+            for cycle in typemap[atom['idx']]['cycles']:
                 if len(cycle) == cycle_len:
                     return True
             return False
         elif atom_id.data == 'ring_count':
-            n_cycles = len(typemap[atom.idx]['cycles'])
+            n_cycles = len(typemap[atom['idx']]['cycles'])
             if n_cycles == int(atom_id.children[0]):
                 return True
             return False
@@ -171,8 +172,13 @@ class SMARTSGraph(nx.Graph):
         _prepare_atoms(structure, typemap, compute_cycles=has_ring_rules)
 
         top_graph = nx.Graph()
-        top_graph.add_nodes_from(((a.idx, {'atom': a})
-                                  for a in structure.atoms))
+        top_graph.add_nodes_from(((
+            a.idx, {'idx': a.idx,
+                    'n_bond_partners': len(a.bond_partners),
+                    'atomic_number': a.element,
+                    'name': a.name})
+            for a in structure.atoms)
+        )
         top_graph.add_edges_from(((b.atom1.idx, b.atom2.idx)
                                   for b in structure.bonds))
 

--- a/foyer/smarts_graph.py
+++ b/foyer/smarts_graph.py
@@ -95,8 +95,6 @@ class SMARTSGraph(nx.Graph):
     def _node_match(self, host, pattern):
         """ Determine if two graph nodes are equal """
         atom_expr = pattern['atom'].children[0]
-        #atom = host['atom']
-        #return self._atom_expr_matches(atom_expr, atom)
         return self._atom_expr_matches(atom_expr, host)
 
     def _atom_expr_matches(self, atom_expr, atom):

--- a/foyer/tests/test_graph.py
+++ b/foyer/tests/test_graph.py
@@ -1,6 +1,6 @@
 import parmed as pmd
 
-from foyer.smarts_graph import SMARTSGraph, _prepare_atoms
+from foyer.smarts_graph import SMARTSGraph, _prepare_atoms, _construct_topological_graph
 from foyer.tests.utils import get_fn
 
 
@@ -47,7 +47,8 @@ def test_cycle_finding_multiple():
                             'atomtype': None}     
                             for atom in mol2.atoms}
 
-    _prepare_atoms(mol2, typemap, compute_cycles=True)
+    top_graph = _construct_topological_graph(mol2)
+    typemap = _prepare_atoms(top_graph, typemap)
     cycle_lengths = [list(map(len, typemap[atom.idx]['cycles'])) 
                         for atom in mol2.atoms]
     expected = [5, 6, 6]


### PR DESCRIPTION
Looking at https://github.com/mosdef-hub/foyer/pull/348, I'm concerned there's a lot of spaghetti code to handle both parmed and gmso objects. I think for some "upstream" foyer processing, it might be an important stopgap to accommodate both objects, but a lot of the downstream graph matching code within foyer's `smarts_graph.py` shouldn't have to change. Namely, generalize the properties of the topological graph's nodes to be more "primitive" properties (like index, symbol, number, n_bond_partners) instead of the node's singular property being a bulky parmed atom (or gmso site) which contains the relevant properties. This PR tries to address this:

* Rework `smarts_graph.find_matches` so the properties of the topological graph are the primitive properties of each atom, not a parmed atom that wraps the primitive properties. This should make graph processing slightly more lightweight so that the parmed objects don't have to be carried around. This also establishes a pattern for swapping out parmed objects with gmso objects.

* Refactor `smarts_graph._atom_id_matches` to accommodate the new design of the topological graph. We no longer need to access atomic properties of the parmed atoms via the properties of the networkx node; we only need to access atomic properties stored directly within the networkx node

This was putting code to paper to demonstrate the idea/solution. But my primary concern still remains: when making a stable transition from parmed to gmso, we should try to minimize the amount of duplicate code. This could be done by trying to generalize downstream code to be less library-dependent, but upstream processing code may still have to be library-dependent