### PR TITLE
Fix typo in forcefield.py

### DIFF
--- a/foyer/forcefield.py
+++ b/foyer/forcefield.py
@@ -914,7 +914,7 @@ class Forcefield(app.ForceField):
         for atom in structure.atoms:
             atom.id = typemap[atom.idx]['atomtype']
 
-        if not all([a.id for a in structure.atoms][0]):
+        if not all([a.id for a in structure.atoms]):
             raise ValueError('Not all atoms in topology have atom types')
 
     def _prepare_structure(self, topology, **kwargs):


### PR DESCRIPTION
### PR Summary:
I think I found this typo in `forcefield.py`: 

```       
 if not all([a.id for a in structure.atoms][0]):
     raise ValueError('Not all atoms in topology have atom types')
```

I think that `[0]` should not be there since it kills the purpose of `all()`. 
### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
