### PR TITLE
Fix docker link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Alternatively, you can also start a Bourne shell directly:
 $ docker run -it --name foyer mosdef/foyer:latest
 ```
 
-To learn more about using `foyer` with docker, please refer to the documentation `<here https://foyer.mosdef.org/en/latest/docker.html>_` .
+To learn more about using `foyer` with docker, please refer to the documentation [here](https://foyer.mosdef.org/en/latest/docker.html) .
 
 
 #### Getting started with SMARTS-based atom-typing


### PR DESCRIPTION
The link to docker tutorial was not rendering correctly in README, this PR fixes it.