### PR TITLE
Update installation docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,6 @@ WORKDIR /foyer
 
 RUN conda update conda -yq && \
 	conda config --set always_yes yes --set changeps1 no && \
-	conda config --add channels omnia && \
 	conda config --add channels conda-forge && \
 	conda config --add channels mosdef && \
 	. /opt/conda/etc/profile.d/conda.sh && \

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,7 +44,6 @@ stages:
 
           - bash: |
               conda config --set always_yes yes --set changeps1 no
-              conda config --add channels omnia
               conda config --add channels janschulz
               conda config --add channels conda-forge
               conda config --add channels mosdef
@@ -75,7 +74,6 @@ stages:
 
           - script: |
               conda config --set always_yes yes --set changeps1 no
-              conda config --add channels omnia
               conda config --add channels conda-forge
               conda config --add channels mosdef
             displayName: Add Relevent Channels
@@ -102,7 +100,6 @@ stages:
 
           - bash: |
               conda config --set always_yes yes --set changeps1 no
-              conda config --add channels omnia
               conda config --add channels conda-forge
               conda config --add channels mosdef
               conda create -n  bleeding-test-environment python=3.7 --file requirements-dev.txt

--- a/docs/docs-env.yml
+++ b/docs/docs-env.yml
@@ -1,7 +1,6 @@
 name: foyer-docs
 channels:
   - conda-forge
-  - omnia
   - mosdef
 dependencies:
   - python=3.7

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,25 +1,35 @@
 Installation
 ==============
 
-Install from conda:
+Install with `conda <https://repo.anaconda.com/miniconda/>`_
+-----------------------------------------------------
+::
 
-.. code:: bash
+    $ conda install -c conda-forge -c omnia foyer
 
-    conda install -c conda-forge -c omnia -c mosdef foyer
+Alternatively you can add all the required channels to your ``.condarc``
+after which you can simply install without specifying the channels::
 
-Install from pip:
+    $ conda config --add channels omnia
+    $ conda config --add channels conda-forge
+    $ conda install foyer
 
-.. code:: bash
+.. note::
+    The order in which channels are added matters: ``conda-forge`` should be the highest priority as a result of being added last. In your ``.condarc`` file, it should be listed first.
 
-    pip install foyer
+Install with `pip <https://pypi.org/project/pip/>`_
+---------------------------------------------------
+::
 
-Install an editable version from source:
+    $ pip install mbuild
 
-.. code:: bash
+Install an editable version from source
+---------------------------------------
+::
 
-    git clone https://github.com/mosdef-hub/foyer.git
-    cd foyer
-    pip install -e .
+    $ git clone https://github.com/mosdef-hub/mbuild
+    $ cd mbuild
+    $ pip install -e .
 
 Supported Python Versions
 -------------------------

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -5,18 +5,13 @@ Install with `conda <https://repo.anaconda.com/miniconda/>`_
 -----------------------------------------------------
 ::
 
-    $ conda install -c conda-forge -c omnia foyer
+    $ conda install -c conda-forge foyer
 
 Alternatively you can add all the required channels to your ``.condarc``
 after which you can simply install without specifying the channels::
 
-    $ conda config --add channels omnia
     $ conda config --add channels conda-forge
     $ conda install foyer
-
-.. note::
-    The order in which channels are added matters: ``conda-forge`` should be the highest priority as a result of being added last. In your ``.condarc`` file, it should be listed first.
-
 Install with `pip <https://pypi.org/project/pip/>`_
 ---------------------------------------------------
 ::

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -21,14 +21,14 @@ Install with `pip <https://pypi.org/project/pip/>`_
 ---------------------------------------------------
 ::
 
-    $ pip install mbuild
+    $ pip install foyer
 
 Install an editable version from source
 ---------------------------------------
 ::
 
-    $ git clone https://github.com/mosdef-hub/mbuild
-    $ cd mbuild
+    $ git clone https://github.com/mosdef-hub/foyer
+    $ cd foyer
     $ pip install -e .
 
 Supported Python Versions

--- a/docs/tmp/installation.md
+++ b/docs/tmp/installation.md
@@ -1,6 +1,6 @@
 Install from conda:
 ```bash
-conda install -c omnia -c mosdef foyer
+conda install -c mosdef foyer
 ```
 
 Install an editable version from source:


### PR DESCRIPTION
### PR Summary:
Remove `mosdef` channel from installation docs. 


### PR Checklist
------------
 - [x] Includes appropriate unit test(s)
 - [x] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [x] Issue(s) raised/addressed?
