### PR TITLE
Add get_available_forcefield_loaders

### DIFF
--- a/foyer/forcefield.py
+++ b/foyer/forcefield.py
@@ -4,8 +4,9 @@ import itertools
 import os
 from tempfile import NamedTemporaryFile
 import xml.etree.ElementTree as ET
+from typing import List, Callable
 
-from pkg_resources import resource_filename
+from pkg_resources import resource_filename, iter_entry_points
 import warnings
 import re
 
@@ -81,6 +82,15 @@ def preprocess_forcefield_files(forcefield_files=None):
         preprocessed_files.append(temp_file.name)
 
     return preprocessed_files
+
+
+def get_available_forcefield_loaders() -> List[Callable]:
+    """Get a list of available force field loader functions"""
+    available_ff_paths = []
+    for entry_point in iter_entry_points(group="foyer.forcefields"):
+        available_ff_paths.append(entry_point.load())
+
+    return available_ff_paths
 
 
 def generate_topology(non_omm_topology, non_element_types=None, residues=None):

--- a/foyer/tests/test_plugin.py
+++ b/foyer/tests/test_plugin.py
@@ -7,10 +7,10 @@ def test_basic_import():
 
 
 def test_loading_forcefields():
-    #funcs = [func for func in dir(foyer.forcefields) if 'load' in func and '__' not in func]
-    for func in dir(foyer.forcefields):
-        if 'load_' in func and '__' not in func:
-            eval('foyer.forcefields.' + func)()
+    """Test that the forcefield loader functions run without error"""
+    available_loaders = foyer.forcefield.get_available_forcefield_loaders()
+    for loader in available_loaders:
+        loader()
 
 
 def test_load_forcefield():


### PR DESCRIPTION
### PR Summary:
This PR adds a `get_available_forcefield_loaders` function, which returns a list of the functions returning `Forcefield` objects as discovered by the plugin system. I believe there is no other way to systematically access these function in the current API, i.e. from inside Foyer and not the package that plugs into it. In the past I have either called entry points I had in short-term memory or tab-completed `foyer.forcefields.load_` in an interpreter.

### PR Checklist
------------
 - [x] Includes appropriate unit test(s)
 - [x] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
