### PR TITLE
Stop built in FF's from throwing warnings

### DIFF
--- a/foyer/forcefields/forcefields.py
+++ b/foyer/forcefields/forcefields.py
@@ -1,6 +1,7 @@
 import os
 import glob
 from pkg_resources import resource_filename
+import warnings
 
 from foyer import Forcefield
 
@@ -29,8 +30,12 @@ def get_forcefield(name=None):
 
 
 def load_OPLSAA():
-    return get_forcefield(name='oplsaa')
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return get_forcefield(name='oplsaa')
 
 
 def load_TRAPPE_UA():
-    return get_forcefield(name='trappe-ua')
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return get_forcefield(name='trappe-ua')

--- a/foyer/forcefields/forcefields.py
+++ b/foyer/forcefields/forcefields.py
@@ -4,6 +4,7 @@ from pkg_resources import resource_filename
 import warnings
 
 from foyer import Forcefield
+from foyer.validator import ValidationWarning
 
 
 def get_ff_path():
@@ -24,18 +25,19 @@ def get_forcefield(name=None):
     try:
         ff_path = next(val for val in file_paths if name in val)
     except StopIteration:
-        raise ValueError('Could not find force field with name {}'
-                ' in path {}'.format(name, get_ff_path()))
+        raise ValueError(
+            f"Could not find forcefield named {name} in path {get_ff_path()}"
+            )
     return Forcefield(ff_path)
 
 
 def load_OPLSAA():
     with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
+        warnings.simplefilter("ignore", category=ValidationWarning)
         return get_forcefield(name='oplsaa')
 
 
 def load_TRAPPE_UA():
     with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
+        warnings.simplefilter("ignore", category=UserWarning)
         return get_forcefield(name='trappe-ua')

--- a/foyer/forcefields/xml/CHANGELOG.md
+++ b/foyer/forcefields/xml/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Forcefield Changelog
+----
+## OPLS-AA
+
+v0.0.1 - April 15, 2021
+ - started versioning of forcefield xmls
+
+----
+## Trappe-UA
+
+v0.0.1 - April 15, 2021
+ - started versioning of forcefield xmls

--- a/foyer/forcefields/xml/oplsaa.xml
+++ b/foyer/forcefields/xml/oplsaa.xml
@@ -3,7 +3,7 @@
      are imported from the gromacs atomtypes file at
      https://github.com/gromacs/gromacs/blob/aa66efd3179a671aace62b827c54aadc3d89c1ee/share/top/oplsaa.ff/atomtypes.atp
 -->
-<ForceField>
+<ForceField name="OPLS-AA" version="0.0.1">
  <AtomTypes>
   <Type name="opls_001" class="opls_001" element="C" mass="12.011"/>
   <Type name="opls_002" class="opls_002" element="O" mass="15.9994"/>

--- a/foyer/forcefields/xml/trappe-ua.xml
+++ b/foyer/forcefields/xml/trappe-ua.xml
@@ -1,4 +1,4 @@
-<ForceField>
+<ForceField name="Trappe-UA" version="0.0.1">
  <AtomTypes>
   <Type name="O" class="O" element="O" mass="15.99940" def="OH" desc="Oxygen in hydroxyl" doi="10.1021/jp003882x"/>
   <Type name="H" class="H" element="H" mass="1.00800" def="HO" desc="Hydrogen in hydroxyl" doi="10.1021/jp003882x"/>


### PR DESCRIPTION
### PR Summary:
fixes #363 and fixes #340

- Added names and versions to OPLS-AA and TRAPPE-UA
- Added a warnings wrapper to the load functions because the remaining warnings are very unhelpful to users:
```
>>> ff = foyer.forcefields.load_TRAPPE_UA()
/Users/jenny/Projects/foyer/foyer/forcefield.py:526: UserWarning: Non-atomistic element type detected. Creating custom element for _CH4
  warnings.warn('Non-atomistic element type detected. '
/Users/jenny/Projects/foyer/foyer/forcefield.py:526: UserWarning: Non-atomistic element type detected. Creating custom element for _CH3
  warnings.warn('Non-atomistic element type detected. '
/Users/jenny/Projects/foyer/foyer/forcefield.py:526: UserWarning: Non-atomistic element type detected. Creating custom element for _CH2
  warnings.warn('Non-atomistic element type detected. '
/Users/jenny/Projects/foyer/foyer/forcefield.py:526: UserWarning: Non-atomistic element type detected. Creating custom element for _HC
  warnings.warn('Non-atomistic element type detected. '
```
Yes, it is a united-atom FF 😅 
```
>>> ff = foyer.forcefields.load_OPLSAA()
/Users/jenny/Projects/foyer/foyer/validator.py:132: ValidationWarning: You have empty smart definition(s)
  warn("You have empty smart definition(s)", ValidationWarning)
```
Although we should finish adding smarts definitions, probably a user is not going to do anything with this warning!

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [x] Issue(s) raised/addressed?
