### PR TITLE
Update conda yaml files to be more consistent and bug fix

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -91,8 +91,8 @@ stages:
             displayName: Add Relevent Channels
 
           - script: |
-              sed -i -E 's/python.*$/python='$(python.version)'/' environment-win.yml
-              conda env create -f environment-win.yml
+              sed -i -E 's/python.*$/python='$(python.version)'/' environment-dev-win.yml
+              conda env create -f environment-dev-win.yml
               call activate foyer-dev
               pip install -e .
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -132,7 +132,6 @@ stages:
               pip install -e .
               cd src/antefoyer
               pip install -e .
-              cd ../../
             displayName: Create a new bleeding test environment
 
           - bash: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,7 +62,6 @@ stages:
               pip install -e .
               cd src/antefoyer
               pip install -e .
-              cd ../../
             displayName: Create Conda env, Activate, Install dependencies, Install Branch
           - bash: |
               source activate foyer-dev

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -60,10 +60,13 @@ stages:
               conda env create -f environment-dev.yml
               source activate foyer-dev
               pip install -e .
+              cd src/antefoyer
+              pip install -e .
+              cd ../../
             displayName: Create Conda env, Activate, Install dependencies, Install Branch
           - bash: |
               source activate foyer-dev
-              python -m pytest -v --cov=foyer --cov-report=html --pyargs foyer 
+              python -m pytest -v --cov=foyer --cov-report=html --pyargs foyer
             displayName: Run Tests
 
           - bash: |
@@ -95,7 +98,9 @@ stages:
               conda env create -f environment-dev-win.yml
               call activate foyer-dev
               pip install -e .
-
+              cd src/antefoyer
+              pip install -e .
+              cd ../../
             displayName: Create conda env, Install dependencies and Install Branch
 
           - script: |
@@ -126,6 +131,9 @@ stages:
               pip install -e .
               cd ..
               pip install -e .
+              cd src/antefoyer
+              pip install -e .
+              cd ../../
             displayName: Create a new bleeding test environment
 
           - bash: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -99,7 +99,6 @@ stages:
               pip install -e .
               cd src/antefoyer
               pip install -e .
-              cd ../../
             displayName: Create conda env, Install dependencies and Install Branch
 
           - script: |

--- a/environment-dev-win.yml
+++ b/environment-dev-win.yml
@@ -1,0 +1,24 @@
+name: foyer-dev
+channels:
+  - conda-forge
+  - omnia
+dependencies:
+  - bump2version
+  - codecov
+  - lark-parser
+  - lxml
+  - mbuild
+  - networkx>=2.0
+  - openmm>=7.5
+  - parmed
+  - pip
+  - pytest
+  - pytest-azurepipelines
+  - pytest-cov
+  - pytest-timeout
+  - python<=3.8
+  - requests
+  - requests-mock
+  - pip:
+    - "--editable=git+https://github.com/rsdefever/GAFF-foyer.git#egg=gafffoyer"
+    - git+https://github.com/rsdefever/antefoyer.git

--- a/environment-dev-win.yml
+++ b/environment-dev-win.yml
@@ -20,5 +20,4 @@ dependencies:
   - requests
   - requests-mock
   - pip:
-    - "--editable=git+https://github.com/rsdefever/GAFF-foyer.git#egg=gafffoyer"
-    - git+https://github.com/rsdefever/antefoyer.git
+    - "--editable=git+https://github.com/rsdefever/antefoyer.git#egg=antefoyer"

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -19,5 +19,4 @@ dependencies:
   - requests
   - requests-mock
   - pip:
-    - "--editable=git+https://github.com/rsdefever/GAFF-foyer.git#egg=gafffoyer"
     - git+https://github.com/rsdefever/antefoyer.git

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -19,4 +19,4 @@ dependencies:
   - requests
   - requests-mock
   - pip:
-    - git+https://github.com/rsdefever/antefoyer.git
+    - "--editable=git+https://github.com/rsdefever/antefoyer.git#egg=antefoyer"

--- a/environment-win.yml
+++ b/environment-win.yml
@@ -1,24 +1,12 @@
-name: foyer-dev
+name: foyer
 channels:
   - conda-forge
   - omnia
 dependencies:
-  - bump2version
-  - codecov
   - lark-parser
   - lxml
-  - mbuild
   - networkx>=2.0
   - openmm>=7.5
   - parmed
-  - pip
-  - pytest
-  - pytest-azurepipelines
-  - pytest-cov
-  - pytest-timeout
-  - python<=3.8
   - requests
-  - requests-mock
-  - pip:
-    - "--editable=git+https://github.com/rsdefever/GAFF-foyer.git#egg=gafffoyer"
-    - git+https://github.com/rsdefever/antefoyer.git
+  - python<=3.8

--- a/environment.yml
+++ b/environment.yml
@@ -7,4 +7,5 @@ dependencies:
   - networkx>=2.0
   - openmm>=7.5
   - parmed
+  - requests
   - python<=3.8


### PR DESCRIPTION
### PR Summary:

* As is, `environment.yml` does not work because the `requests` package is missing.
* `environment-win.yml` is really a development environment `environment-dev-win.yml`. This file was renamed.
* There is no windows equivalent of `environment.yml`. This has been added.

Right now, creating an development environment with `environment.yml` cause the `GAFF foyer` tests to error: `AttributeError: module 'foyer.forcefields.forcefields' has no attribute 'load_GAFF'`. ~~At first I thought this was because GAFF foyer is installed before foyer. Wasn't there some issue with this @justinGilmer @umesh-timalsina. However, I tried re-installing GAFF foyer before foyer so now I am less certain what has gone wrong.~~ If possible, I would also like to get that fixed before we merge this PR.

**Edit**:  The problem is related to the installation order of editable installs with entry points. If the `foyer` installation is editable, it appears that `antefoyer` needs to be installed after `foyer`. If the installation is not editable, the tests fail to even run with the following error:

```
ImportError while loading conftest '/Users/ryandefever/repos/mosdef/foyer/foyer/tests/conftest.py'.
_pytest.pathlib.ImportPathMismatchError: ('foyer.tests.conftest', '/Users/ryandefever/software/miniconda3/envs/foyer-dev/lib/python3.8/site-packages/foyer/tests/conftest.py', PosixPath('/Users/ryandefever/repos/mosdef/foyer/foyer/tests/conftest.py'))
```