### PR TITLE
Include git in docker image to clone repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,8 @@ ADD . /foyer
 
 WORKDIR /foyer
 
-RUN conda update conda -yq && \
+RUN apk add --no-cache git && \
+        conda update conda -yq && \
 	conda config --set always_yes yes --set changeps1 no && \
 	. /opt/conda/etc/profile.d/conda.sh && \
     sed -i -E "s/python.*$/python="$PY_VERSION"/" environment-dev.yml && \


### PR DESCRIPTION
### PR Summary:
With the new additions of the conda env yml files to our repo, this
inevitably added some unforeseen issues with our release pipeline.

This fixes the case where our docker images would not build, since the
environment-dev.yml file has a `pip:` section that needs to clone a
repository using `git`. `git` is not installed by default in the alpine
docker image, and has been added to the `RUN` command.

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
