### PR TITLE
Pin networkx>=2.5

### DIFF
--- a/environment-dev-win.yml
+++ b/environment-dev-win.yml
@@ -8,7 +8,7 @@ dependencies:
   - lark-parser
   - lxml
   - mbuild
-  - networkx>=2.0
+  - networkx>=2.5
   - openmm>=7.5
   - parmed
   - pip

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -7,7 +7,7 @@ dependencies:
   - lark-parser
   - lxml
   - mbuild
-  - networkx>=2.0
+  - networkx>=2.5
   - openmm>=7.5
   - parmed
   - pip

--- a/environment-win.yml
+++ b/environment-win.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   - lark-parser
   - lxml
-  - networkx>=2.0
+  - networkx>=2.5
   - openmm>=7.5
   - parmed
   - requests

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - lark-parser
   - lxml
-  - networkx>=2.0
+  - networkx>=2.5
   - openmm>=7.5
   - parmed
   - requests


### PR DESCRIPTION
### PR Summary:

Closes #414. 

`networkx 2.3` on `python 3.9` has an issue where it errors on import. I was getting `2.3` by default on `osx`. 