### PR TITLE
Migrate azure pipeline environment creation from conda to mamba

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,8 @@ RUN apk add --no-cache git && \
 	conda config --set always_yes yes --set changeps1 no && \
 	. /opt/conda/etc/profile.d/conda.sh && \
     sed -i -E "s/python.*$/python="$PY_VERSION"/" environment-dev.yml && \
-	conda env create nomkl -f environment-dev.yml && \
+  conda install -c conda-forge mamba && \
+	mamba env create nomkl -f environment-dev.yml && \
 	conda activate foyer-dev && \
         python setup.py install && \
 	echo "source activate foyer-dev" >> \

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -55,9 +55,14 @@ stages:
           - bash: |
               conda config --set always_yes yes --set changeps1 no
             displayName: Add relavent Channels
+
+          - bash: |
+              conda install -c conda-forge mamba
+            displayName: Install mamba
+
           - bash: |
               sed -i -E 's/python.*$/python='$(python.version)'/' environment-dev.yml
-              conda env create -f environment-dev.yml
+              mamba env create -f environment-dev.yml
               source activate foyer-dev
               pip install -e .
               cd src/antefoyer
@@ -117,13 +122,14 @@ stages:
 
           - bash: |
               conda config --set always_yes yes --set changeps1 no
+              conda install -c conda-forge mamba
               pip install conda-merge
               git clone https://github.com/mosdef-hub/mbuild.git
               conda-merge environment-dev.yml mbuild/environment-dev.yml > combine.yml
               sed -iE 's/python.*$/python=3.7/' combine.yml
               sed -iE '/mbuild/d' combine.yml
               sed -iE '/ foyer/d' combine.yml
-              conda env create -n bleeding -f combine.yml
+              mamba env create -n bleeding -f combine.yml
               source activate bleeding
               cd mbuild
               pip install -e .

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -70,7 +70,7 @@ stages:
             displayName: Create Conda env, Activate, Install dependencies, Install Branch
           - bash: |
               source activate foyer-dev
-              python -m pytest -v --cov=foyer --cov-report=html --pyargs foyer
+              python -m pytest -v --cov=foyer --cov-report=html --color=yes --pyargs foyer
             displayName: Run Tests
 
           - bash: |
@@ -108,7 +108,7 @@ stages:
 
           - script: |
               call activate foyer-dev
-              python -m pytest -v --cov=foyer --pyargs foyer
+              python -m pytest -v --cov=foyer --color=yes --pyargs foyer
             displayName: Run Tests
 
       - job: LinuxBleedingMbuild
@@ -123,15 +123,11 @@ stages:
           - bash: |
               conda config --set always_yes yes --set changeps1 no
               conda install -c conda-forge mamba
-              pip install conda-merge
               git clone https://github.com/mosdef-hub/mbuild.git
-              conda-merge environment-dev.yml mbuild/environment-dev.yml > combine.yml
-              sed -iE 's/python.*$/python=3.7/' combine.yml
-              sed -iE '/mbuild/d' combine.yml
-              sed -iE '/ foyer/d' combine.yml
-              mamba env create -n bleeding -f combine.yml
+              mamba env create --name bleeding --file environment-dev.yml
               source activate bleeding
               cd mbuild
+              mamba env update --name bleeding --file environment.yml
               pip install -e .
               cd ..
               pip install -e .
@@ -141,7 +137,7 @@ stages:
 
           - bash: |
               source activate bleeding
-              python -m pytest -v --cov=foyer --cov-report= --pyargs foyer
+              python -m pytest -v --cov=foyer --cov-report=html --color=yes --pyargs foyer
             displayName: Run Tests
 
 


### PR DESCRIPTION
### PR Summary:
Previously, all conda environment creations use conda for the
dependency resolution, which is notoriously slower than mamba's
implementation.

This can have a noticeable impact on run times during CI as well as
building docker images. Mamba has replaced conda in our dockerfile as
well as our azurepipelines.yml file.

NOTE: mamba is not used for windows builds, due to previous issues
attempting to use mamba.

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
