### PR TITLE
Update smarts string for opls_154

### DIFF
--- a/foyer/forcefields/xml/CHANGELOG.md
+++ b/foyer/forcefields/xml/CHANGELOG.md
@@ -24,6 +24,9 @@ v0.0.2 - June 24, 2021
     - opls_468 (from `"10.1021/ja9539195"` to `"10.1002/jcc.1092"`)
     - opls_469 (from `"10.1021/ja9539195"` to `"10.1002/jcc.1092"`)
 
+v0.0.3 - August 7, 2021
+ - update SMARTS string for opls_154 (from `[O;X2]H` to `[O;X2](H)([!H])`)
+
 ----
 ## Trappe-UA
 

--- a/foyer/forcefields/xml/oplsaa.xml
+++ b/foyer/forcefields/xml/oplsaa.xml
@@ -3,7 +3,7 @@
      are imported from the gromacs atomtypes file at
      https://github.com/gromacs/gromacs/blob/aa66efd3179a671aace62b827c54aadc3d89c1ee/share/top/oplsaa.ff/atomtypes.atp
 -->
-<ForceField name="OPLS-AA" version="0.0.2" combining_rule="geometric">
+<ForceField name="OPLS-AA" version="0.0.3" combining_rule="geometric">
 
  <AtomTypes>
   <Type name="opls_001" class="opls_001" element="C" mass="12.011"/>
@@ -157,7 +157,7 @@
   <Type name="opls_151" class="Cl" element="Cl" mass="35.453" def="[Cl][C;X4]" overrides="opls_401" desc="Cl in alkyl chlorides" doi="10.1021/jp0484579"/>
   <Type name="opls_152" class="CT" element="C" mass="12.011" def="[C;X4](Cl)([Cl,C,H])([Cl,C,H])([Cl,C,H])" desc="RCH2Cl in alkyl chlorides" doi="10.1021/jp0484579"/>
   <Type name="opls_153" class="HC" element="H" mass="1.008" def="[H][C;X4](Cl)([Cl,C,H])([Cl,C,H])" overrides="opls_140" desc="H in alkyl chlorides" doi="10.1021/jp0484579"/>
-  <Type name="opls_154" class="OH" element="O" mass="15.9994"   def="[O;X2]H" desc="all-atom O: mono alcohols" doi="10.1021/ja9621760"/>
+  <Type name="opls_154" class="OH" element="O" mass="15.9994"   def="[O;X2](H)([!H])" desc="all-atom O: mono alcohols" doi="10.1021/ja9621760"/>
   <Type name="opls_155" class="HO" element="H" mass="1.00800"   def="H[O;%opls_154]" desc="all-atom H(O): mono alcohols, OP(=O)2" doi="10.1021/ja9621760"/>
   <Type name="opls_156" class="HC" element="H" mass="1.008" def="HC(H)(H)OH" desc="all-atom H(C): methanol" overrides="opls_140" doi="10.1021/ja9621760"/>
   <Type name="opls_157" class="CT" element="C" mass="12.01100"   def="[C;X4]([H])([H])([*])[O;%opls_154]" desc="all-atom C: CH3 and CH2, alcohols" overrides="opls_136, opls_159, opls_158" doi="10.1021/ja9621760"/>

--- a/foyer/tests/test_forcefield.py
+++ b/foyer/tests/test_forcefield.py
@@ -651,13 +651,13 @@ class TestForcefield(BaseTest):
 
     def test_load_metadata_from_internal_forcefield_plugin_loader(self):
         from_xml_ff = forcefields.load_OPLSAA()
-        assert from_xml_ff.version == "0.0.2"
+        assert from_xml_ff.version == "0.0.3"
         assert from_xml_ff.name == "OPLS-AA"
         assert from_xml_ff.combining_rule == "geometric"
 
     def test_load_metadata_from_internal_name(self):
         from_xml_ff = Forcefield(name="oplsaa")
-        assert from_xml_ff.version == "0.0.2"
+        assert from_xml_ff.version == "0.0.3"
         assert from_xml_ff.name == "OPLS-AA"
         assert from_xml_ff.combining_rule == "geometric"
 

--- a/foyer/tests/test_opls.py
+++ b/foyer/tests/test_opls.py
@@ -46,7 +46,7 @@ class TestOPLS(BaseTest):
 
     def test_opls_metadata(self, oplsaa):
         assert oplsaa.name == "OPLS-AA"
-        assert oplsaa.version == "0.0.2"
+        assert oplsaa.version == "0.0.3"
         assert oplsaa.combining_rule == "geometric"
 
     @pytest.mark.parametrize("mol_name", correctly_implemented)


### PR DESCRIPTION
### PR Summary:

Update definition of `opls_154` in `oplsaa.xml`, raised by #438. Tests were updated accordingly. 

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
