### PR TITLE
Feat/trappe ua combrule

### DIFF
--- a/foyer/forcefield.py
+++ b/foyer/forcefield.py
@@ -544,7 +544,7 @@ class Forcefield(app.ForceField):
                 self._combining_rule = self._combining_rule[0]
             else:
                 raise FoyerError(
-                    "Inconsistent combining_rule among loaded forecfield files"
+                    "Inconsistent combining_rule among loaded forcefield files"
                 )
         for fp in preprocessed_files:
             os.remove(fp)

--- a/foyer/forcefields/xml/CHANGELOG.md
+++ b/foyer/forcefields/xml/CHANGELOG.md
@@ -29,3 +29,5 @@ v0.0.2 - June 24, 2021
 
 v0.0.1 - April 15, 2021
  - started versioning of forcefield xmls
+v0.0.2 - August 9, 2021
+ - Updated `combining_rule` to `lorentz`

--- a/foyer/forcefields/xml/trappe-ua.xml
+++ b/foyer/forcefields/xml/trappe-ua.xml
@@ -1,4 +1,4 @@
-<ForceField name="Trappe-UA" version="0.0.1">
+<ForceField name="Trappe-UA" version="0.0.2" combining_rule="lorentz">
  <AtomTypes>
   <Type name="O" class="O" element="O" mass="15.99940" def="OH" desc="Oxygen in hydroxyl" doi="10.1021/jp003882x"/>
   <Type name="H" class="H" element="H" mass="1.00800" def="HO" desc="Hydrogen in hydroxyl" doi="10.1021/jp003882x"/>

--- a/foyer/tests/test_trappe.py
+++ b/foyer/tests/test_trappe.py
@@ -54,6 +54,13 @@ class TestTraPPE(BaseTest):
             structure = pmd.load_file(mol2_path, structure=True)
             atomtype(structure, TRAPPE_UA)
 
+    def test_trappe_metadata(
+        self,
+    ):
+        assert TRAPPE_UA.name == "Trappe-UA"
+        assert TRAPPE_UA.version == "0.0.2"
+        assert TRAPPE_UA.combining_rule == "lorentz"
+
 
 if __name__ == "__main__":
     TestTraPPE().find_correctly_implemented()


### PR DESCRIPTION
### PR Summary:
After the addition of the `combining_rule` forcefield XML metadata, we
added the `geometric` mixing rule to oplsaa.xml, but neglected to
include that information for our TraPPE xml.

This includes the `Lorentz-Berethlot` mixing rule as metadata as well as
bumping the version number for the trappe-ua.xml file.

A minor spelling mistake was also fixed.

### PR Checklist
------------
 - [x] Includes appropriate unit test(s)
 - [x] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
