### PR TITLE
Add OPLS Parameters for ADOPA

### DIFF
--- a/foyer/forcefields/xml/oplsaa.xml
+++ b/foyer/forcefields/xml/oplsaa.xml
@@ -799,7 +799,7 @@
   <Type name="opls_909" class="H" element="H" mass="1.00800" def="H[N;%opls_900]" desc="H(N) primary amines" doi="10.1021/ja984106u"/>
   <Type name="opls_910" class="H" element="H" mass="1.008" def="H[N;%opls_901]" desc="H(N) secondary amines" doi="10.1021/ja984106u"/>
   <Type name="opls_911" class="HC" element="H" mass="1.00800" def="H([C;%opls_903,%opls_904,%opls_905,%opls_906,%opls_908])" desc="H(C) for C bonded to N in amines, diamines (aziridine H2,H3)" overrides="opls_140" doi="10.1021/ja984106u"/>
-  <Type name="opls_912" class="opls_912" element="C" mass="12.011"/>
+  <Type name="opls_912" class="CT" element="C" mass="12.011" def="[C;X4]([N;%opls_900])(H)CC" desc="CH primary isopropyl amine" doi="10.1021/ja984106u"/>
   <Type name="opls_912B" class="opls_912B" element="C" mass="12.011"/>
   <Type name="opls_913" class="opls_913" element="C" mass="12.011"/>
   <Type name="opls_914" class="opls_914" element="C" mass="12.011"/>


### PR DESCRIPTION
### PR Summary:
ADOPA is molecule similar to that of L-DOPA (https://en.wikipedia.org/wiki/L-DOPA) (See image below).
The atom type for the carbon bonded to the amine group (opls_912) needed to be added to properly atom type the molecule.

Currently the following dihedral parameters are missing:
```
Missing dihedral with ids (15, 14, 39, 40) and types ['opls_465', 'opls_912', 'opls_900', 'opls_909'].
Missing dihedral with ids (15, 14, 39, 41) and types ['opls_465', 'opls_912', 'opls_900', 'opls_909'].
Missing dihedral with ids (18, 15, 14, 39) and types ['opls_466', 'opls_465', 'opls_912', 'opls_900'].
Missing dihedral with ids (19, 15, 14, 39) and types ['opls_467', 'opls_465', 'opls_912', 'opls_900'].
```
which corresponds to `C_2-CT-NT-H` and `O_2-C_2-CT-NT`.  I need to do some further digging to find these dihedral parameters.  For this reason, along with lack of unit testing for this molecule, I am opening as a draft right now.

![adopa](https://user-images.githubusercontent.com/25011342/130473716-cc1ba171-ac1e-4d6a-8d20-a35757be4ea8.png)
  

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
