### PR TITLE
Remove simtk references for openmm 7.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,11 @@ file, annotated with SMARTS-based atomtypes, e.g.:
 
 Foyer can apply the forcefield to arbitrary chemical topologies. We currently support:
 
-* [OpenMM.Topology](http://docs.openmm.org/7.0.0/api-python/generated/simtk.openmm.app.topology.Topology.html#)
+* [OpenMM.Topology](https://github.com/openmm/openmm/blob/7.6.0/wrappers/python/openmm/app/topology.py#L70)
 * [ParmEd.Structure](http://parmed.github.io/ParmEd/html/structure.html)
 * [mBuild.Compound](http://mosdef-hub.github.io/mbuild/data_structures.html)
+* [gmso.Topology](https://gmso.mosdef.org/en/stable/data_structures.html#gmso.Topology)
+* [openff.tookit.topology.Topology](https://open-forcefield-toolkit.readthedocs.io/en/0.9.2/api/generated/openff.toolkit.topology.Topology.html#openff-toolkit-topology-topology)
 
 Application of a force field can be as simple as:
 ```python

--- a/docs/docs-env.yml
+++ b/docs/docs-env.yml
@@ -6,7 +6,7 @@ dependencies:
   - python=3.7
   - gmso
   - openmm>=7.6
-  - parmed
+  - parmed>=3.4.3
   - ele
   - pip:
     - sphinx

--- a/docs/docs-env.yml
+++ b/docs/docs-env.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   - python=3.7
   - gmso
-  - openmm =7.5
+  - openmm>=7.6
   - parmed
   - ele
   - pip:

--- a/environment-dev-win.yml
+++ b/environment-dev-win.yml
@@ -10,7 +10,7 @@ dependencies:
   - mbuild
   - gmso
   - networkx>=2.5
-  - openmm=7.5
+  - openmm>=7.6
   - parmed
   - pip
   - pytest

--- a/environment-dev-win.yml
+++ b/environment-dev-win.yml
@@ -11,7 +11,7 @@ dependencies:
   - gmso
   - networkx>=2.5
   - openmm>=7.6
-  - parmed
+  - parmed>=3.4.3
   - pip
   - pytest
   - pytest-azurepipelines

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -9,7 +9,7 @@ dependencies:
   - mbuild
   - gmso
   - networkx>=2.5
-  - openmm=7.5
+  - openmm>=7.6
   - parmed
   - ele
   - openff-toolkit

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -10,7 +10,7 @@ dependencies:
   - gmso
   - networkx>=2.5
   - openmm>=7.6
-  - parmed
+  - parmed>=3.4.3
   - ele
   - openff-toolkit
   - gmso

--- a/environment-win.yml
+++ b/environment-win.yml
@@ -7,7 +7,7 @@ dependencies:
   - lxml
   - networkx>=2.5
   - openmm>=7.6
-  - parmed
+  - parmed>=3.4.3
   - ele
   - requests
   - pip

--- a/environment-win.yml
+++ b/environment-win.yml
@@ -6,7 +6,7 @@ dependencies:
   - lark-parser
   - lxml
   - networkx>=2.5
-  - openmm=7.5
+  - openmm>=7.6
   - parmed
   - ele
   - requests

--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - gmso
   - networkx>=2.5
   - openmm>=7.6
-  - parmed
+  - parmed>=3.4.3
   - ele
   - requests
   - python<=3.8

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ dependencies:
   - lxml
   - gmso
   - networkx>=2.5
-  - openmm=7.5
+  - openmm>=7.6
   - parmed
   - ele
   - requests

--- a/foyer/element.py
+++ b/foyer/element.py
@@ -1,11 +1,11 @@
 """Element support in foyer."""
-import simtk.openmm.app.element as elem
+import openmm.app.element as elem
 
 
 class Element(elem.Element):
     """An Element represents a chemical element.
 
-    The simtk.openmm.app.element module contains objects for all the standard chemical elements,
+    The openmm.app.element module contains objects for all the standard chemical elements,
     such as element.hydrogen or element.carbon.  You can also call the static method Element.getBySymbol() to
     look up the Element with a particular chemical symbol.
 

--- a/foyer/forcefield.py
+++ b/foyer/forcefield.py
@@ -11,13 +11,12 @@ from tempfile import NamedTemporaryFile
 from typing import Callable, Iterable, List
 
 import numpy as np
+import openmm as mm
+import openmm.app.element as elem
+import openmm.unit as u
 import parmed as pmd
-import simtk.openmm.app.element as elem
-import simtk.unit as u
-from pkg_resources import iter_entry_points, resource_filename
-from simtk import openmm as mm
-from simtk.openmm import app
-from simtk.openmm.app.forcefield import (
+from openmm import app
+from openmm.app.forcefield import (
     AllBonds,
     CutoffNonPeriodic,
     HAngles,
@@ -30,6 +29,7 @@ from simtk.openmm.app.forcefield import (
     RBTorsionGenerator,
     _convertParameterToNumber,
 )
+from pkg_resources import iter_entry_points, resource_filename
 
 import foyer.element as custom_elem
 from foyer import smarts


### PR DESCRIPTION
This PR removes all the simtk references for openmm imports and should be merged after https://github.com/ParmEd/ParmEd/issues/1185 is resolved. Tests will fail for the timebeing.
