### PR TITLE
Update openmm

### DIFF
--- a/docs/docs-env.yml
+++ b/docs/docs-env.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   - python=3.7
   - gmso
-  - openmm =7.5
+  - openmm=7.6
   - parmed
   - ele
   - pip:

--- a/environment-dev-win.yml
+++ b/environment-dev-win.yml
@@ -10,7 +10,7 @@ dependencies:
   - mbuild
   - gmso
   - networkx>=2.5
-  - openmm=7.5
+  - openmm=7.6
   - parmed
   - pip
   - pytest

--- a/environment-dev-win.yml
+++ b/environment-dev-win.yml
@@ -10,7 +10,7 @@ dependencies:
   - mbuild
   - gmso
   - networkx>=2.5
-  - openmm=7.6
+  - openmm>=7.6
   - parmed
   - pip
   - pytest

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -9,7 +9,7 @@ dependencies:
   - mbuild
   - gmso
   - networkx>=2.5
-  - openmm=7.6
+  - openmm>=7.6
   - parmed
   - ele
   - openff-toolkit

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -9,7 +9,7 @@ dependencies:
   - mbuild
   - gmso
   - networkx>=2.5
-  - openmm=7.5
+  - openmm=7.6
   - parmed
   - ele
   - openff-toolkit

--- a/environment-win.yml
+++ b/environment-win.yml
@@ -6,7 +6,7 @@ dependencies:
   - lark-parser
   - lxml
   - networkx>=2.5
-  - openmm=7.6
+  - openmm>=7.6
   - parmed
   - ele
   - requests

--- a/environment-win.yml
+++ b/environment-win.yml
@@ -6,7 +6,7 @@ dependencies:
   - lark-parser
   - lxml
   - networkx>=2.5
-  - openmm=7.5
+  - openmm=7.6
   - parmed
   - ele
   - requests

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ dependencies:
   - lxml
   - gmso
   - networkx>=2.5
-  - openmm=7.6
+  - openmm>=7.6
   - parmed
   - ele
   - requests

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ dependencies:
   - lxml
   - gmso
   - networkx>=2.5
-  - openmm=7.5
+  - openmm=7.6
   - parmed
   - ele
   - requests

--- a/foyer/element.py
+++ b/foyer/element.py
@@ -1,13 +1,14 @@
 """Element support in foyer."""
-import simtk.openmm.app.element as elem
+import openmm.app.element as elem
 
 
 class Element(elem.Element):
     """An Element represents a chemical element.
 
-    The simtk.openmm.app.element module contains objects for all the standard chemical elements,
-    such as element.hydrogen or element.carbon.  You can also call the static method Element.getBySymbol() to
-    look up the Element with a particular chemical symbol.
+    The simtk.openmm.app.element module contains objects for all the standard
+    chemical elements such as element.hydrogen or element.carbon. You can also
+    call the static method Element.getBySymbol() to look up the Element with a
+    particular chemical symbol.
 
     Element objects should be considered immutable.
 

--- a/foyer/forcefield.py
+++ b/foyer/forcefield.py
@@ -12,12 +12,12 @@ from typing import Callable, Iterable, List
 
 import numpy as np
 import parmed as pmd
-import simtk.openmm.app.element as elem
+import openmm.app.element as elem
 import simtk.unit as u
 from pkg_resources import iter_entry_points, resource_filename
-from simtk import openmm as mm
-from simtk.openmm import app
-from simtk.openmm.app.forcefield import (
+import openmm as mm
+from openmm import app
+from openmm.app.forcefield import (
     AllBonds,
     CutoffNonPeriodic,
     HAngles,

--- a/foyer/forcefield.py
+++ b/foyer/forcefield.py
@@ -11,11 +11,10 @@ from tempfile import NamedTemporaryFile
 from typing import Callable, Iterable, List
 
 import numpy as np
-import parmed as pmd
-import openmm.app.element as elem
-import simtk.unit as u
-from pkg_resources import iter_entry_points, resource_filename
 import openmm as mm
+import openmm.app.element as elem
+import parmed as pmd
+import simtk.unit as u
 from openmm import app
 from openmm.app.forcefield import (
     AllBonds,
@@ -30,6 +29,7 @@ from openmm.app.forcefield import (
     RBTorsionGenerator,
     _convertParameterToNumber,
 )
+from pkg_resources import iter_entry_points, resource_filename
 
 import foyer.element as custom_elem
 from foyer import smarts

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-openmm >=7.5
+openmm >=7.6
 mbuild
 parmed
 networkx >=2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-openmm ==7.5
+openmm ==7.6
 parmed
 networkx >=2.0
 lark-parser

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-openmm ==7.6
+openmm >=7.6
 parmed
 networkx >=2.0
 lark-parser


### PR DESCRIPTION
### PR Summary:
It seems that the openmm version update only broke the way we import this library, so this updates the imports. 

This matters to me because I am trying to get gpu-compiled hoomd from conda working in the reproducibility study, but the openmm version seems to be tied to an older version of cudatoolkit, which prevents it from working.

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
