### PR TITLE
Use codecov uploader in favor of bash uploader for coverage reports

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -70,14 +70,18 @@ stages:
             displayName: Create Conda env, Activate, Install dependencies, Install Branch
           - bash: |
               source activate foyer-dev
-              python -m pytest -v --cov=foyer --cov-report=html --color=yes --pyargs foyer
+              python -m pytest -v --cov=foyer --cov-report=html --color=yes --pyargs foyer --cov-config=setup.cfg
             displayName: Run Tests
 
           - bash: |
               source activate foyer-dev
-              bash <(curl -s https://codecov.io/bash) -C $(Build.SourceVersion)
+              curl -Os https://uploader.codecov.io/latest/linux/codecov
+              chmod +x codecov
+              ./codecov -t ${CODECOV_UPLOAD_TOKEN} -C $(Build.SourceVersion)
             condition: and( eq( variables['Agent.OS'], 'Linux' ), eq( variables['python.version'], '3.7' ) )
             displayName: Upload coverage report to codecov.io
+            env:
+              CODECOV_UPLOAD_TOKEN: $(codecovUploadToken)
 
       - job: Windows_no_bleeding
         pool:


### PR DESCRIPTION
### PR Summary:
https://docs.codecov.com/docs/about-the-codecov-bash-uploader#deprecation-notice-and-schedule 

Suggests that the bash uploader we use will be deprecated soon. This PR uses the recommended codecov uploader to upload coverage reports.

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s): N/A 
 - [ ] Appropriate docstring(s) are added/updated: N/A
 - [ ] Code is (approximately) PEP8 compliant: N/A
 - [ ] Issue(s) raised/addressed? : N/A 
