### PR TITLE
Return periodic torsion params, regardless of k value

### DIFF
--- a/foyer/forcefield.py
+++ b/foyer/forcefield.py
@@ -1638,10 +1638,9 @@ class Forcefield(app.ForceField):
     def _get_periodic_torsion_params(torsion):
         params = {"periodicity": [], "phase": [], "k": []}
         for i in range(len(torsion.phase)):
-            if torsion.k[i] != 0:
-                params["periodicity"].append(torsion.periodicity[i])
-                params["phase"].append(torsion.phase[i])
-                params["k"].append(torsion.k[i])
+            params["periodicity"].append(torsion.periodicity[i])
+            params["phase"].append(torsion.phase[i])
+            params["k"].append(torsion.k[i])
 
         return params
 

--- a/foyer/tests/test_forcefield_parameters.py
+++ b/foyer/tests/test_forcefield_parameters.py
@@ -78,6 +78,18 @@ class TestForcefieldParameters(BaseTest):
             [3.141592653589793, 3.141592653589793],
         )
 
+    def test_gaff_periodic_proper_params_zero_k(self, gaff):
+        periodic_proper_params = gaff.get_parameters(
+            "periodic_propers", ["", "c", "c1", ""]
+        )
+        assert all(len(param) for param in periodic_proper_params.values())
+        assert np.allclose(periodic_proper_params["periodicity"], [2.0])
+        assert np.allclose(periodic_proper_params["k"], [0.0])
+        assert np.allclose(
+            periodic_proper_params["phase"],
+            [3.141592653589793],
+        )
+
     def test_gaff_periodic_proper_parameters_reversed(self, gaff):
         assert np.allclose(
             list(


### PR DESCRIPTION
### PR Summary:
See #470 for further details. Previously, we didn't return any parameters if the value of `k == 0`. This PR attempts to fix that. Resolves #470.


### PR Checklist
------------
 - [x] Includes appropriate unit test(s)
 - [x] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [x] Issue(s) raised/addressed?
