### PR TITLE
update xml_writer for improper dihedral

### DIFF
--- a/foyer/xml_writer.py
+++ b/foyer/xml_writer.py
@@ -282,11 +282,19 @@ def _write_periodic_torsions(root, dihedrals, unique):
                 dihedral_force.set("id4", str(dihedral.atom4.idx))
         for id in range(4):
             dihedral_force.set("type{}".format(id + 1), atypes[id])
-        dihedral_force.set("periodicity1", str(dihedral.type.per))
-        dihedral_force.set(
-            "phase1", str(round(dihedral.type.phase * (np.pi / 180), 8))
-        )
-        dihedral_force.set("k1", str(round(dihedral.type.phi_k * 4.184, 3)))
+        
+        try:
+            dihedral_force.set("periodicity1", str(dihedral.type.per))
+            dihedral_force.set(
+                "phase1", str(round(dihedral.type.phase * (np.pi / 180), 8))
+            )
+            dihedral_force.set("k1", str(round(dihedral.type.phi_k * 4.184, 3)))
+        except:
+            dihedral_force.set("periodicity1", str(dihedral.type[0].per))
+            dihedral_force.set(
+                "phase1", str(round(dihedral.type[0].phase * (np.pi / 180), 8))
+            )
+            dihedral_force.set("k1", str(round(dihedral.type[0].phi_k * 4.184, 3)))
         if last_dihedral_force is not None:
             # Check to see if this current dihedral force needs to be
             # "merged" into the last dihedral force


### PR DESCRIPTION


### PR Summary:

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
xml_writer.py produce error for improper dihedral in GAFF force field, and this pull request will solve it.