### PR TITLE
Fix scaling factors and mixing rule bug when atomtype with `general_forcefield` 

### DIFF
--- a/foyer/general_forcefield.py
+++ b/foyer/general_forcefield.py
@@ -373,8 +373,9 @@ class Forcefield(object):
         # Assign ImproperTypes
         for improper in top.impropers:
             self._connection_type_lookup(improper)
-        # Assign combining rules
+        # Assign combining rules and mixing rules
         top.combining_rule = combining_rule
+        top.scaling_factors = self.ff.scaling_factors
         return top
 
     def _connection_type_lookup(self, connection):

--- a/foyer/general_forcefield.py
+++ b/foyer/general_forcefield.py
@@ -375,7 +375,10 @@ class Forcefield(object):
             self._connection_type_lookup(improper)
         # Assign combining rules and mixing rules
         top.combining_rule = combining_rule
-        top.scaling_factors = self.ff.scaling_factors
+        for key in self.ff.scaling_factors.keys():
+            msg = f"Incorrect scaling_factors key word provided: {key}"
+            assert key in top.scaling_factors.keys(), msg
+        top.scaling_factors.update(self.ff.scaling_factors)
         return top
 
     def _connection_type_lookup(self, connection):


### PR DESCRIPTION
### PR Summary:
Currently, when perform atomtyping with `general_forcefield.Forcefield`, the `combining_rule` and `scaling_factors` are not being transferred correctly. This PR makes sure the `scaling_factors` is passed correctly to the final `gmso.Topology`. The `combining_rule` can be specified during the `Forcefield.apply()` called, but I just realized that the `combining_rule` is not an attribute of GMSO Forcefield, so that will be implemented in a separate PR (in GMSO). 
### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
