### PR TITLE
Storing meta data in pmd structure

### DIFF
--- a/foyer/forcefield.py
+++ b/foyer/forcefield.py
@@ -29,6 +29,7 @@ from openmm.app.forcefield import (
     RBTorsionGenerator,
     _convertParameterToNumber,
 )
+from parmed.gromacs.gromacstop import _Defaults
 from pkg_resources import iter_entry_points, resource_filename
 
 import foyer.element as custom_elem
@@ -902,6 +903,20 @@ class Forcefield(app.ForceField):
                 "Structure's total charge: {}".format(total_charge)
             )
 
+        # Start storing scaling factors and combining rule to parmed structure
+        # Utilizing parmed gromactop's _Default class
+
+        # Note: nb_func = 1 (LJ) or 2 (Buckingham), foyer forcefield only support 1 at the moment
+        # Combining rule follow GROMACS scheme, where "lorentz" is 2 and "geometric" is 3
+        combining_rules = {"lorentz": 2, "geometric": 3}
+        gen_pairs = "yes" if structure.adjusts else "no"
+        structure.defaults = _Defaults(
+            nbfunc=1,
+            comb_rule=combining_rules[self.combining_rule],
+            gen_pairs=gen_pairs,
+            fudgeLJ=self.lj14scale,
+            fudgeQQ=self.coulomb14scale,
+        )
         return structure
 
     def createSystem(

--- a/foyer/tests/test_forcefield.py
+++ b/foyer/tests/test_forcefield.py
@@ -439,7 +439,7 @@ class TestForcefield(BaseTest):
         with pytest.warns(ValidationWarning):
             ff = Forcefield(forcefield_files=get_fn("empty_def.xml"))
 
-        with pytest.warns():
+        with pytest.warns(UserWarning):
             typed = ff.apply(ethane)
         assert typed.defaults is None
 

--- a/foyer/tests/test_forcefield.py
+++ b/foyer/tests/test_forcefield.py
@@ -7,6 +7,7 @@ from typing import List
 import parmed as pmd
 import pytest
 from lxml import etree as ET
+from parmed.gromacs.gromacstop import _Defaults
 from pkg_resources import resource_filename
 
 from foyer import Forcefield, forcefields
@@ -93,6 +94,17 @@ class TestForcefield(BaseTest):
         ethane = oplsaa.apply(mol2)
 
         assert ethane.box_vectors == mol2.box_vectors
+
+    def test_structure_meta(self, oplsaa):
+        mol2 = pmd.load_file(get_fn("ethane.mol2"), structure=True)
+        ethane = oplsaa.apply(mol2)
+
+        assert isinstance(ethane.defaults, _Defaults)
+        assert ethane.defaults.nbfunc == 1
+        assert ethane.defaults.comb_rule == 3
+        assert ethane.defaults.fudgeLJ == oplsaa.lj14scale
+        assert ethane.defaults.fudgeQQ == oplsaa.coulomb14scale
+        assert ethane.defaults.gen_pairs == "yes"
 
     @pytest.mark.skipif(not has_mbuild, reason="mbuild is not installed")
     def test_from_mbuild(self, oplsaa):
@@ -426,7 +438,10 @@ class TestForcefield(BaseTest):
         ethane = mb.load(get_fn("ethane.mol2"))
         with pytest.warns(ValidationWarning):
             ff = Forcefield(forcefield_files=get_fn("empty_def.xml"))
-        ff.apply(ethane)
+
+        with pytest.warns():
+            typed = ff.apply(ethane)
+        assert typed.defaults is None
 
     @pytest.mark.skipif(not has_mbuild, reason="mbuild is not installed")
     def test_assert_bonds(self):


### PR DESCRIPTION
### PR Summary:
Relate to #495. Start storing meta data like combining rule and scaling factors in parametrized parmed structure. Currently utilizing the `_Defaults` class from `parmed.gromacs.gromacstop` so terminology may be GROMACS specific, but the info can be stored and access there. 

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
