### PR TITLE
Add CITATION.cff file for easier repo citation

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,45 +12,45 @@ type: software
 authors:
   - given-names: Christoph
     family-names: Klein
-    affiliation: Vanderbilt University
-  - given-names: Andrew Z.
+    affiliation: "Vanderbilt University"
+  - given-names: "Andrew Z."
     family-names: Summers
-    affiliation: Vanderbilt University
+    affiliation: "Vanderbilt University"
     orcid: 'https://orcid.org/0000-0001-8477-3059'
-  - given-names: Matthew W.
+  - given-names: "Matthew W."
     family-names: Thompson
-    affiliation: Vanderbilt University
+    affiliation: "Vanderbilt University"
     orcid: 'https://orcid.org/0000-0002-1460-3983'
-  - given-names: Justin B.
+  - given-names: "Justin B."
     family-names: Gilmer
-    affiliation: Vanderbilt University
+    affiliation: "Vanderbilt University"
     orcid: 'https://orcid.org/0000-0002-6915-5591'
-  - given-names: Co D.
+  - given-names: "Co D."
     family-names: Quach
-    affiliation: Vanderbilt University
+    affiliation: "Vanderbilt University"
     orcid: 'https://orcid.org/0000-0002-1255-4161'
   - given-names: Umesh
     family-names: Timalsina
-    affiliation: Vanderbilt University
+    affiliation: "Vanderbilt University"
     orcid: 'https://orcid.org/0000-0002-5430-3993'
   - given-names: Peter
     family-names: Volgyesi
     orcid: 'https://orcid.org/0000-0002-7478-4317'
-    affiliation: Vanderbilt University
+    affiliation: "Vanderbilt University"
   - given-names: Janos
     family-names: Sallai
-    affiliation: Vanderbilt University
-  - given-names: Chris R.
+    affiliation: "Vanderbilt University"
+  - given-names: "Chris R."
     family-names: Iacovella
-    affiliation: Vanderbilt University
+    affiliation: "Vanderbilt University"
     orcid: 'https://orcid.org/0000-0003-0557-0427'
-  - given-names: Clare M.
+  - given-names: Clare
     family-names: McCabe
-    affiliation: Vanderbilt University
+    affiliation: "Vanderbilt University"
     orcid: 'https://orcid.org/0000-0002-8552-9135'
-  - given-names: Peter T.
+  - given-names: "Peter T."
     family-names: Cummings
-    affiliation: Vanderbilt University
+    affiliation: "Vanderbilt University"
     orcid: 'https://orcid.org/0000-0002-9766-2216'
 identifiers:
   - type: doi
@@ -82,33 +82,33 @@ preferred-citation:
   - authors:
     - given-names: Christoph
       family-names: Klein
-      affiliation: Vanderbilt University
-    - given-names: Andrew Z.
+      affiliation: "Vanderbilt University"
+    - given-names: "Andrew Z."
       family-names: Summers
-      affiliation: Vanderbilt University
+      affiliation: "Vanderbilt University"
       orcid: 'https://orcid.org/0000-0001-8477-3059'
-    - given-names: Matthew W.
+    - given-names: "Matthew W."
       family-names: Thompson
-      affiliation: Vanderbilt University
+      affiliation: "Vanderbilt University"
       orcid: 'https://orcid.org/0000-0002-1460-3983'
-    - given-names: Justin B.
+    - given-names: "Justin B."
       family-names: Gilmer
-      affiliation: Vanderbilt University
+      affiliation: "Vanderbilt University"
       orcid: 'https://orcid.org/0000-0002-6915-5591'
-    - given-names: Clare M.
+    - given-names: Clare
       family-names: McCabe
-      affiliation: Vanderbilt University
+      affiliation: "Vanderbilt University"
       orcid: 'https://orcid.org/0000-0002-8552-9135'
-    - given-names: Peter T.
+    - given-names: "Peter T."
       family-names: Cummings
-      affiliation: Vanderbilt University
+      affiliation: "Vanderbilt University"
       orcid: 'https://orcid.org/0000-0002-9766-2216'
     - given-names: Janos
       family-names: Sallai
-      affiliation: Vanderbilt University
-    - given-names: Chris R.
+      affiliation: "Vanderbilt University"
+    - given-names: "Chris R."
       family-names: Iacovella
-      affiliation: Vanderbilt University
+      affiliation: "Vanderbilt University"
       orcid: 'https://orcid.org/0000-0003-0557-0427'
   - title: "Formalizing atom-typing and the dissemination of force fields with foyer"
   - journal: "Comput. Mater. Sci."

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,79 @@
+# This CITATION.cff file was generated with cffinit.
+# Visit https://bit.ly/cffinit to generate yours today!
+
+cff-version: 1.2.0
+title: >-
+  Foyer: A package for atom-typing as well as
+  applying and disseminating forcefields
+message: >-
+  If you use this software, please cite it using the
+  metadata from this file.
+type: software
+authors:
+  - given-names: Christoph
+    family-names: Klein
+    affiliation: Vanderbilt University
+  - given-names: Andrew
+    family-names: Z. Summers
+    affiliation: Vanderbilt University
+    orcid: 'https://orcid.org/0000-0001-8477-3059'
+  - given-names: Matthew
+    family-names: W. Thompson
+    affiliation: Vanderbilt University
+    orcid: 'https://orcid.org/0000-0002-1460-3983'
+  - given-names: Justin
+    family-names: B. Gilmer
+    affiliation: Vanderbilt University
+    orcid: 'https://orcid.org/0000-0002-6915-5591'
+  - given-names: Co
+    family-names: D. Quach
+    affiliation: Vanderbilt University
+    orcid: 'https://orcid.org/0000-0002-1255-4161'
+  - given-names: Umesh
+    family-names: Timalsina
+    affiliation: Vanderbilt University
+    orcid: 'https://orcid.org/0000-0002-5430-3993'
+  - given-names: Janos
+    family-names: Sallai
+    affiliation: Vanderbilt University
+  - given-names: Chris R.
+    family-names: Iacovella
+    affiliation: Vanderbilt University
+    orcid: 'https://orcid.org/0000-0003-0557-0427'
+  - given-names: Clare M.
+    family-names: McCabe
+    affiliation: Vanderbilt University
+    orcid: 'https://orcid.org/0000-0002-8552-9135'
+  - given-names: Peter T.
+    family-names: Cummings
+    affiliation: Vanderbilt University
+    orcid: 'https://orcid.org/0000-0002-9766-2216'
+  - given-names: Peter
+    family-names: Volgyesi
+    orcid: 'https://orcid.org/0000-0002-7478-4317'
+    affiliation: Vanderbilt University
+identifiers:
+  - type: doi
+    value: 10.5281/zenodo.6229092
+    description: Zenodo Doi
+repository-code: 'https://github.com/mosdef-hub/foyer'
+url: 'https://foyer.mosdef.org'
+repository: 'https://github.com/mosdef-hub/foyer'
+repository-artifact: 'https://github.com/mosdef-hub/foyer/releases'
+abstract: >-
+  Foyer is an open-source Python tool for defining
+  and applying force field atom-typing rules in a
+  format that is both human- and machine-readable. It
+  parametrizes chemical topologies, generating,
+  syntactically correct input files for various
+  simulation engines. Foyer provides a framework for
+  force field dissemination, helping to eliminate
+  ambiguity in atom-typing and improving
+  reproducibility.
+keywords:
+  - atom-typing
+  - reproducibility
+  - 'TRUE'
+  - mosdef
+  - python
+license: MIT

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -78,8 +78,8 @@ keywords:
   - python
 license: MIT
 preferred-citation:
-  - type: article
-  - authors:
+  type: article
+  authors:
     - given-names: Christoph
       family-names: Klein
       affiliation: "Vanderbilt University"
@@ -110,9 +110,9 @@ preferred-citation:
       family-names: Iacovella
       affiliation: "Vanderbilt University"
       orcid: 'https://orcid.org/0000-0003-0557-0427'
-  - title: "Formalizing atom-typing and the dissemination of force fields with foyer"
-  - journal: "Comput. Mater. Sci."
-  - volume: 167
-  - pages: 12
-  - year: 2019
-  - doi: "https://doi.org/10.1016/j.commatsci.2019.05.026"
+  title: "Formalizing atom-typing and the dissemination of force fields with foyer"
+  journal: "Comput. Mater. Sci."
+  volume: "167"
+  pages: "12"
+  year: "2019"
+  doi: "10.1016/j.commatsci.2019.05.026"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -13,26 +13,30 @@ authors:
   - given-names: Christoph
     family-names: Klein
     affiliation: Vanderbilt University
-  - given-names: Andrew
-    family-names: Z. Summers
+  - given-names: Andrew Z.
+    family-names: Summers
     affiliation: Vanderbilt University
     orcid: 'https://orcid.org/0000-0001-8477-3059'
-  - given-names: Matthew
-    family-names: W. Thompson
+  - given-names: Matthew W.
+    family-names: Thompson
     affiliation: Vanderbilt University
     orcid: 'https://orcid.org/0000-0002-1460-3983'
-  - given-names: Justin
-    family-names: B. Gilmer
+  - given-names: Justin B.
+    family-names: Gilmer
     affiliation: Vanderbilt University
     orcid: 'https://orcid.org/0000-0002-6915-5591'
-  - given-names: Co
-    family-names: D. Quach
+  - given-names: Co D.
+    family-names: Quach
     affiliation: Vanderbilt University
     orcid: 'https://orcid.org/0000-0002-1255-4161'
   - given-names: Umesh
     family-names: Timalsina
     affiliation: Vanderbilt University
     orcid: 'https://orcid.org/0000-0002-5430-3993'
+  - given-names: Peter
+    family-names: Volgyesi
+    orcid: 'https://orcid.org/0000-0002-7478-4317'
+    affiliation: Vanderbilt University
   - given-names: Janos
     family-names: Sallai
     affiliation: Vanderbilt University
@@ -48,10 +52,6 @@ authors:
     family-names: Cummings
     affiliation: Vanderbilt University
     orcid: 'https://orcid.org/0000-0002-9766-2216'
-  - given-names: Peter
-    family-names: Volgyesi
-    orcid: 'https://orcid.org/0000-0002-7478-4317'
-    affiliation: Vanderbilt University
 identifiers:
   - type: doi
     value: 10.5281/zenodo.6229092
@@ -77,3 +77,42 @@ keywords:
   - mosdef
   - python
 license: MIT
+references:
+  - type: article
+  - authors:
+    - given-names: Christoph
+      family-names: Klein
+      affiliation: Vanderbilt University
+    - given-names: Andrew Z.
+      family-names: Summers
+      affiliation: Vanderbilt University
+      orcid: 'https://orcid.org/0000-0001-8477-3059'
+    - given-names: Matthew W.
+      family-names: Thompson
+      affiliation: Vanderbilt University
+      orcid: 'https://orcid.org/0000-0002-1460-3983'
+    - given-names: Justin B.
+      family-names: Gilmer
+      affiliation: Vanderbilt University
+      orcid: 'https://orcid.org/0000-0002-6915-5591'
+    - given-names: Clare M.
+      family-names: McCabe
+      affiliation: Vanderbilt University
+      orcid: 'https://orcid.org/0000-0002-8552-9135'
+    - given-names: Peter T.
+      family-names: Cummings
+      affiliation: Vanderbilt University
+      orcid: 'https://orcid.org/0000-0002-9766-2216'
+    - given-names: Janos
+      family-names: Sallai
+      affiliation: Vanderbilt University
+    - given-names: Chris R.
+      family-names: Iacovella
+      affiliation: Vanderbilt University
+      orcid: 'https://orcid.org/0000-0003-0557-0427'
+  - title: "Formalizing atom-typing and the dissemination of force fields with foyer"
+  - journal: "Comput. Mater. Sci."
+  - volume: 167
+  - pages: 12
+  - year: 2019
+  - doi: "https://doi.org/10.1016/j.commatsci.2019.05.026"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -7,7 +7,7 @@ title: >-
   applying and disseminating forcefields
 message: >-
   If you use this software, please cite it using the
-  metadata from this file.
+  metadata from this file and the preferred citation.
 type: software
 authors:
   - given-names: Christoph
@@ -77,7 +77,7 @@ keywords:
   - mosdef
   - python
 license: MIT
-references:
+preferred-citation:
   - type: article
   - authors:
     - given-names: Christoph


### PR DESCRIPTION
### PR Summary:
GitHub has added native support of the CITATION.cff file format, which
provides a nice way to generate a citation for a software repository.

This adds in a basic citation.cff file, which can be updated as
necessary.

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
