### PR TITLE
Update docs environment to use Python 3.8+

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,9 +1,13 @@
 version: 2
 formats:
   - htmlzip
+  - pdf
 conda:
   environment: docs/docs-env.yml
-
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "mambaforge-4.10"
 sphinx:
   builder: html
   configuration: docs/source/conf.py

--- a/docs/docs-env.yml
+++ b/docs/docs-env.yml
@@ -2,9 +2,8 @@ name: foyer-docs
 channels:
   - jaimergp/label/unsupported-cudatoolkit-shim
   - conda-forge
-  - omnia
 dependencies:
-  - python=3.7
+  - python>=3.8
   - gmso
   - openmm>=7.6
   - parmed>=3.4.3


### PR DESCRIPTION
### PR Summary:

After #513, RTD builds are failing. This may be due to the docs environment being pinned to a (now) unsupported Python version. You'd think I would have noticed that after looking at the files off and on for months, but you'd be wrong.

This PR updates that and gives Mambaforge a try (Micromamba isn't [supported](https://docs.readthedocs.io/en/stable/config-file/v2.html#build-tools-python) yet).

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
