### PR TITLE
Update how xml_writer derive the structure.defaults

### DIFF
--- a/foyer/xml_writer.py
+++ b/foyer/xml_writer.py
@@ -461,6 +461,10 @@ def _infer_lj14scale(struct, combining_rule: str):
     """Infer the Lennard-Jones 1-4 scaling factor in the structure."""
     lj14scale = list()
 
+    if struct.defaults:
+        combining_rules = {2: "lorentz", 3: "geometric"}
+        return combining_rules[struct.defaults.comb_rule]
+
     for adj in struct.adjusts:
         type1 = adj.atom1.atom_type
         type2 = adj.atom2.atom_type


### PR DESCRIPTION
### PR Summary:
Currently in the xml_writer is indirectly inferring the combining rule from the structure.adjusts. However, since now we populate and store the combining rule in `structure.defaults` (if that structure is typed and parameterized with foyer), it makes more sense refer that directly from there. 
 
### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
