### PR TITLE
Turn off fail-fast

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -16,13 +16,14 @@ jobs:
     name: Foyer Tests
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [macOS-latest, ubuntu-latest, windows-latest]
         python-version: ["3.8", "3.9"]
         exclude:
           - os: windows-latest
             python-version: "3.8"
-        fail-fast: false
+
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -22,7 +22,7 @@ jobs:
         exclude:
           - os: windows-latest
             python-version: "3.8"
-
+        fail-fast: false
     defaults:
       run:
         shell: bash -l {0}


### PR DESCRIPTION
### PR Summary:
Right now, if what of the check failed, all the other unfinished checks will get canceled, which miss the point of testing on different OS. This PR turns that off. Similar to https://github.com/mosdef-hub/mbuild/pull/1067
### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
