### PR TITLE
Update nbfix to use parmed structure.copy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
     - id: black
       args: [--line-length=80]
 - repo: https://github.com/pycqa/isort
-  rev: 5.11.4
+  rev: 5.12.0
   hooks:
     - id: isort
       name: isort (python)

--- a/foyer/utils/nbfixes.py
+++ b/foyer/utils/nbfixes.py
@@ -1,5 +1,5 @@
 """Support non-bonded fixes for various interactions."""
-from copy import deepcopy
+from parmed import Structure
 
 
 def apply_nbfix(struct, atom_type1, atom_type2, sigma, epsilon):
@@ -23,7 +23,7 @@ def apply_nbfix(struct, atom_type1, atom_type2, sigma, epsilon):
     struct : parmed.structure.Structure
         The input structure with the nbfix applied.
     """
-    struct_copy = deepcopy(struct)
+    struct_copy = struct.copy(cls=Structure, split_dihedrals=True)
 
     atom_types = list({a.atom_type for a in struct_copy.atoms})
     for atom_type in sorted(atom_types, key=lambda a: a.name):


### PR DESCRIPTION
### PR Summary:

Resolves #529 

By using deepcopy() in foyer.utils.nbfixes.apply_nbfix, the parmed structure loses the following attributes ['links', 'symmetry', 'defaults']. Without links, there is an error when copying the structure in mbuild.lammpsdata.

  File ".....mbuild/mbuild/formats/lammpsdata.py", line 170, in write_lammpsdata
    structure = structure.copy(cls=Structure, split_dihedrals=True)
  File ".....python3.8/site-packages/parmed/structure.py", line 613, in copy
    for l in self.links:

### PR Checklist
------------
 - [X] Includes appropriate unit test(s)
 - [X] Appropriate docstring(s) are added/updated
 - [X] Code is (approximately) PEP8 compliant
 - [X] Issue(s) raised/addressed?
