### PR TITLE
change default of use_residue_map to be False

### DIFF
--- a/foyer/forcefield.py
+++ b/foyer/forcefield.py
@@ -723,7 +723,7 @@ class Forcefield(app.ForceField):
         self,
         structure,
         references_file=None,
-        use_residue_map=True,
+        use_residue_map=False,
         assert_bond_params=True,
         assert_angle_params=True,
         assert_dihedral_params=True,
@@ -741,7 +741,7 @@ class Forcefield(app.ForceField):
         references_file : str, optional, default=None
             Name of file where force field references will be written (in Bibtex
             format)
-        use_residue_map : boolean, optional, default=True
+        use_residue_map : boolean, optional, default=False
             Store atomtyped topologies of residues to a dictionary that maps
             them to residue names.  Each topology, including atomtypes, will be
             copied to other residues with the same name. This avoids repeatedly

--- a/foyer/tests/test_utils.py
+++ b/foyer/tests/test_utils.py
@@ -15,7 +15,7 @@ class TestUtils(BaseTest):
         or pmd.version.major < 4
         or (
             pmd.version.major == 4
-            and pmd.version.minor == pmd.version.patchlvel == 0
+            and pmd.version.minor == pmd.version.patchlevel == 0
         ),
         reason="obsolete parmed version",
     )

--- a/foyer/tests/test_utils.py
+++ b/foyer/tests/test_utils.py
@@ -15,7 +15,7 @@ class TestUtils(BaseTest):
         or pmd.version.major < 4
         or (
             pmd.version.major == 4
-            and pmd.verion.minor == pmd.version.patchlvel == 0
+            and pmd.version.minor == pmd.version.patchlvel == 0
         ),
         reason="obsolete parmed version",
     )

--- a/foyer/utils/nbfixes.py
+++ b/foyer/utils/nbfixes.py
@@ -42,5 +42,4 @@ def apply_nbfix(struct, atom_type1, atom_type2, sigma, epsilon):
         if atom_type.name == atom_type2:
             atom_type.add_nbfix(atom_type1, rmin, epsilon)
 
-
     return struct_copy

--- a/foyer/utils/nbfixes.py
+++ b/foyer/utils/nbfixes.py
@@ -25,16 +25,8 @@ def apply_nbfix(struct, atom_type1, atom_type2, sigma, epsilon):
     """
     struct_copy = struct.copy(cls=Structure, split_dihedrals=True)
 
-    atom_types = list({a.atom_type for a in struct_copy.atoms})
-    for atom_type in sorted(atom_types, key=lambda a: a.name):
-        if atom_type.name == atom_type1:
-            a1 = atom_type
-        if atom_type.name == atom_type2:
-            a2 = atom_type
-    try:
-        a1
-        a2
-    except NameError:
+    atypes_name = set(a.atom_type.name for a in struct_copy.atoms)
+    if atom_type1 not in atypes_name or atom_type2 not in atypes_name:
         raise ValueError(
             "Atom types {} and {} not found "
             "in structure.".format(atom_type1, atom_type2)
@@ -42,7 +34,13 @@ def apply_nbfix(struct, atom_type1, atom_type2, sigma, epsilon):
 
     # Calculate rmin from sigma because parmed uses it internally
     rmin = sigma * 2 ** (1.0 / 6.0)
-    a1.add_nbfix(a2.name, rmin, epsilon)
-    a2.add_nbfix(a1.name, rmin, epsilon)
+
+    atom_types = list(a.atom_type for a in struct_copy.atoms)
+    for atom_type in sorted(atom_types, key=lambda a: a.name):
+        if atom_type.name == atom_type1:
+            atom_type.add_nbfix(atom_type2, rmin, epsilon)
+        if atom_type.name == atom_type2:
+            atom_type.add_nbfix(atom_type1, rmin, epsilon)
+
 
     return struct_copy


### PR DESCRIPTION
### PR Summary:
Address https://github.com/mosdef-hub/mbuild/issues/1111. Change the default of `use_residue_map` in `Forcefield.apply` to `False`, since this may be produced unexpected behavior if users try to atomtype of systems with similar residue name. 

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
