### PR TITLE
Do not use deprecated OpenFF Toolkit iterator

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -13,7 +13,7 @@ dependencies:
   - openmm
   - parmed>=3.4.3
   - ele
-  - openff-toolkit >=0.11.0
+  - openff-toolkit >=0.14
   - gmso
   - pip
   - pre-commit

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -13,7 +13,7 @@ dependencies:
   - openmm
   - parmed>=3.4.3
   - ele
-  - openff-toolkit >=0.14
+  - openff-toolkit >=0.11
   - gmso
   - pip
   - pre-commit

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -26,3 +26,4 @@ dependencies:
   - requests-mock
   - pip:
     - "--editable=git+https://github.com/rsdefever/antefoyer.git#egg=antefoyer"
+    - git+https://github.com/openforcefield/openff-toolkit.git

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -26,4 +26,3 @@ dependencies:
   - requests-mock
   - pip:
     - "--editable=git+https://github.com/rsdefever/antefoyer.git#egg=antefoyer"
-    - git+https://github.com/openforcefield/openff-toolkit.git

--- a/foyer/topology_graph.py
+++ b/foyer/topology_graph.py
@@ -197,7 +197,7 @@ class TopologyGraph(nx.Graph):
         if uses_old_api:
             from parmed import periodic_table as pt
 
-            for top_atom in openff_topology.topology_atoms:
+            for top_atom in openff_topology.atoms:
                 atom = top_atom.atom
                 element_symbol = pt.Element[atom.atomic_number]
                 top_graph.add_atom(


### PR DESCRIPTION
### PR Summary:

`Topology.topology_atoms` was deprecated in 0.11.0 and will be removed in the forthcoming 0.14.0 release.

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
