### PR TITLE
Do not use 'old' OpenFF Toolkit API

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -50,7 +50,7 @@ jobs:
         run: python -m pip install -e .
 
       - name: Test (OS -> ${{ matrix.os }} / Python -> ${{ matrix.python-version }})
-        run: python -m pytest -v --cov=foyer --cov-report=xml --cov-append --cov-config=setup.cfg --color yes --pyargs foyer
+        run: python -m pytest -v -nauto --cov=foyer --cov-report=xml --cov-append --cov-config=setup.cfg --color yes --pyargs foyer
 
       - name: Upload Coverage Report
         uses: codecov/codecov-action@v2
@@ -95,7 +95,7 @@ jobs:
 
       - name: Run Bleeding Edge Tests
         run: |
-          python -m pytest -v --color yes --pyargs foyer
+          python -m pytest -v -nauto --color yes --pyargs foyer
 
   docker:
     runs-on: ubuntu-latest

--- a/environment-dev-win.yml
+++ b/environment-dev-win.yml
@@ -18,6 +18,7 @@ dependencies:
   - pytest-azurepipelines
   - pytest-cov
   - pytest-timeout
+  - pytest-xdist
   - python>=3.8
   - requests
   - requests-mock

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -21,6 +21,7 @@ dependencies:
   - pytest-azurepipelines
   - pytest-cov
   - pytest-timeout
+  - pytest-xdist
   - python>=3.8
   - requests
   - requests-mock

--- a/environment-win.yml
+++ b/environment-win.yml
@@ -15,4 +15,5 @@ dependencies:
   - pytest-azurepipelines
   - pytest-cov
   - pytest-timeout
+  - pytest-xdist
   - python<=3.8


### PR DESCRIPTION
### PR Summary:

A change I made to the toolkit (https://github.com/openforcefield/openff-toolkit/pull/1661) involved changing how attributes are looked up, which made this check

```
        uses_old_api = hasattr(Topology(), "_topology_molecules")
```

no longer produce the same behavior as when I wrote it. With 0.14.4, released last night, this line erroneously evaluates to `True`. There would be a few ways to fix this, but I'm proposing to just remove the dual support. We are no longer supporting the "old" (< 0.11) versions of the toolkit. Note, of course, that this change wouldn't affect any released version of Foyer.

I also noticed tests aren't run in parallel - it's a small and straightforward fix to get CI to use the multiple cores that [GHA provides 
](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources). I'm lazy.

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
