### PR TITLE
Drop Testing for py38 in Windows

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -22,8 +22,10 @@ jobs:
         python-version: ["3.8", "3.9", "3.10"]
         exclude:
           - os: windows-latest
-            python-version: ["3.8", "3.9"]
-
+            python-version: "3.8"
+          - os: windows-latest
+            python-version: "3.9"
+  
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -25,7 +25,7 @@ jobs:
             python-version: "3.8"
           - os: windows-latest
             python-version: "3.9"
-  
+
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -22,7 +22,7 @@ jobs:
         python-version: ["3.8", "3.9", "3.10"]
         exclude:
           - os: windows-latest
-            python-version: "3.9"
+            python-version: ["3,8", "3.9"]
 
     defaults:
       run:

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -22,7 +22,7 @@ jobs:
         python-version: ["3.8", "3.9", "3.10"]
         exclude:
           - os: windows-latest
-            python-version: ["3,8", "3.9"]
+            python-version: ["3.8", "3.9"]
 
     defaults:
       run:


### PR DESCRIPTION
### PR Summary:
We again bumped into unknown error for windows py3.8 test, probably similar to that seen windows py3.9. This PR will temporarily drop the test for windows py3.8 CI run. 

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
