### PR TITLE
add python 3.12 and macOS-13 to test matrix

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -11,18 +11,51 @@ on:
     - cron:  "0 0 * * *"
 
 jobs:
-  test:
+  python-test:
     if: github.event.pull_request.draft == false
-    name: Foyer Tests
+    name: Foyer Tests (python)
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    steps:
+      - uses: actions/checkout@v3
+        name: Checkout Branch / Pull Request
+
+      - name: Install Mamba (Linux)
+        uses: mamba-org/setup-micromamba@v1
+        with:
+          environment-file: environment-dev.yml
+          create-args: python=${{ matrix.python-version }}
+
+      - name: Install Package
+        run: python -m pip install -e .
+
+      - name: Test (OS -> ${{ matrix.os }} / Python -> ${{ matrix.python-version }})
+        run: python -m pytest -v -nauto --cov=foyer --cov-report=xml --cov-append --cov-config=setup.cfg --color yes --pyargs foyer
+
+      - name: Upload Coverage Report
+        uses: codecov/codecov-action@v2
+        with:
+          name: Foyer-Coverage
+          verbose: true
+          files: ./coverage.xml
+  os-test:
+    if: github.event.pull_request.draft == false
+    name: Foyer Tests (arch)
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [macOS-latest, macOS-13, ubuntu-latest, windows-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
-        exclude:
-          - os: windows-latest
-            python-version: "3.9"
+        python-version: ["3.12"]
 
     defaults:
       run:
@@ -50,14 +83,7 @@ jobs:
         run: python -m pip install -e .
 
       - name: Test (OS -> ${{ matrix.os }} / Python -> ${{ matrix.python-version }})
-        run: python -m pytest -v -nauto --cov=foyer --cov-report=xml --cov-append --cov-config=setup.cfg --color yes --pyargs foyer
-
-      - name: Upload Coverage Report
-        uses: codecov/codecov-action@v2
-        with:
-          name: Foyer-Coverage
-          verbose: true
-          files: ./coverage.xml
+        run: python -m pytest -v -nauto --color yes --pyargs foyer
 
   bleeding-edge-test:
     if: github.event.pull_request.draft == false

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -85,7 +85,6 @@ jobs:
         run: |
           micromamba update --name foyer-dev --file mbuild/environment.yml
           micromamba update --name foyer-dev --file gmso/environment.yml
-          micromamba install -c conda-forge hoomd
 
       - name: Install Packages from Source
         run: |

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -11,7 +11,7 @@ on:
     - cron:  "0 0 * * *"
 
 jobs:
-  python-test:
+  test:
     if: github.event.pull_request.draft == false
     name: Foyer Tests (python)
     runs-on: ${{ matrix.os }}
@@ -47,7 +47,8 @@ jobs:
           name: Foyer-Coverage
           verbose: true
           files: ./coverage.xml
-  os-test:
+
+  arch-test:
     if: github.event.pull_request.draft == false
     name: Foyer Tests (arch)
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -18,8 +18,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macOS-latest, ubuntu-latest, windows-latest]
-        python-version: ["3.9", "3.10", "3.11"]
+        os: [macOS-latest, macOS-13, ubuntu-latest, windows-latest]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
         exclude:
           - os: windows-latest
             python-version: "3.9"

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -75,7 +75,7 @@ jobs:
         uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: environment-dev.yml
-          create-args: python=3.10
+          create-args: python=3.12
       - name: Clone mBuild and GMSO
         run: |
           git clone https://github.com/mosdef-hub/mbuild.git
@@ -85,6 +85,7 @@ jobs:
         run: |
           micromamba update --name foyer-dev --file mbuild/environment.yml
           micromamba update --name foyer-dev --file gmso/environment.yml
+          micromamba install -c conda-forge hoomd
 
       - name: Install Packages from Source
         run: |

--- a/environment-dev-win.yml
+++ b/environment-dev-win.yml
@@ -19,6 +19,6 @@ dependencies:
   - pytest-cov
   - pytest-timeout
   - pytest-xdist
-  - python>=3.8
+  - python>=3.9
   - requests
   - requests-mock

--- a/environment-dev-win.yml
+++ b/environment-dev-win.yml
@@ -7,7 +7,7 @@ dependencies:
   - codecov
   - lark-parser
   - lxml
-  - mbuild
+  - mbuild>=0.17
   - treelib
   - gmso
   - networkx>=2.5

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -22,6 +22,6 @@ dependencies:
   - pytest-cov
   - pytest-timeout
   - pytest-xdist
-  - python>=3.8
+  - python>=3.9
   - requests
   - requests-mock

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -6,7 +6,7 @@ dependencies:
   - codecov
   - lark-parser
   - lxml
-  - mbuild
+  - mbuild>=0.17
   - treelib
   - gmso
   - networkx>=2.5

--- a/environment-win.yml
+++ b/environment-win.yml
@@ -6,7 +6,7 @@ dependencies:
   - lark-parser
   - lxml
   - networkx>=2.5
-  - openmm>=7.6
+  - openmm
   - parmed>=3.4.3
   - ele
   - requests
@@ -16,4 +16,4 @@ dependencies:
   - pytest-cov
   - pytest-timeout
   - pytest-xdist
-  - python<=3.8
+  - python>=3.9

--- a/environment.yml
+++ b/environment.yml
@@ -10,4 +10,4 @@ dependencies:
   - parmed>=3.4.3
   - ele
   - requests
-  - python>=3.8
+  - python>=3.9

--- a/foyer/tests/files/ethane_customtype.pdb
+++ b/foyer/tests/files/ethane_customtype.pdb
@@ -9,7 +9,7 @@ ATOM    5   _Hb  ETH     1       2.956   1.278  -9.381  0.00  0.00           H
 ATOM    6   _Hb  ETH     1       4.748   0.049  -7.277  0.00  0.00           H
 ATOM    7   _Hb  ETH     1       5.187   0.312  -8.947  0.00  0.00           H
 ATOM    8   _Hb  ETH     1       4.890   1.676  -7.897  0.00  0.00           H
-CONECT 1    2     3     4     5     6     7     8
+CONECT 1    2     3     4     5
 CONECT 2    1     6     7     8
 CONECT 1    2
 CONECT 1    3

--- a/foyer/tests/files/ethane_customtype.pdb
+++ b/foyer/tests/files/ethane_customtype.pdb
@@ -11,7 +11,7 @@ ATOM    7   _Hb  ETH     1       5.187   0.312  -8.947  0.00  0.00           H
 ATOM    8   _Hb  ETH     1       4.890   1.676  -7.897  0.00  0.00           H
 CONECT 1    2     3     4     5     6     7     8
 CONECT 2    1     6     7     8
-CONECT 1    2 
+CONECT 1    2
 CONECT 1    3
 CONECT 1    4
 CONECT 1    5

--- a/foyer/tests/files/ethane_customtype.pdb
+++ b/foyer/tests/files/ethane_customtype.pdb
@@ -9,7 +9,9 @@ ATOM    5   _Hb  ETH     1       2.956   1.278  -9.381  0.00  0.00           H
 ATOM    6   _Hb  ETH     1       4.748   0.049  -7.277  0.00  0.00           H
 ATOM    7   _Hb  ETH     1       5.187   0.312  -8.947  0.00  0.00           H
 ATOM    8   _Hb  ETH     1       4.890   1.676  -7.897  0.00  0.00           H
-CONECT 1    2
+CONECT 1    2     3     4     5     6     7     8
+CONECT 2    1     6     7     8
+CONECT 1    2 
 CONECT 1    3
 CONECT 1    4
 CONECT 1    5

--- a/foyer/tests/test_forcefield.py
+++ b/foyer/tests/test_forcefield.py
@@ -684,7 +684,12 @@ class TestForcefield(BaseTest):
         mol1.name = "CCC"
         mol2.name = "COC"
 
-        box = mb.fill_box([mol1, mol2], n_compounds=[2, 2], density=700)
+        box = mb.fill_box(
+                [mol1, mol2],
+                n_compounds=[2, 2],
+                overlap=0.01,
+                density=700
+        )
 
         all_substructures = []
         structure = box.to_parmed(residues=["CCC", "COC"])


### PR DESCRIPTION
### PR Summary:

mBuild and GMSO have started testing with python 3.12 and both versions of MacOS, we should do that here as well.

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
