### PR TITLE
Ensure XML files are opened with UTF-8 encoding

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -13,7 +13,7 @@ dependencies:
   - openmm
   - parmed>=3.4.3
   - ele
-  - openff-toolkit >=0.11
+  - openff-toolkit-base >=0.11
   - pip
   - pre-commit
   - pytest

--- a/foyer/forcefield.py
+++ b/foyer/forcefield.py
@@ -66,15 +66,17 @@ def preprocess_forcefield_files(forcefield_files=None):
 
     for xml_file in forcefield_files:
         if not hasattr(xml_file, "read"):
-            f = open(xml_file)
+            try:
+                f = open(xml_file, encoding="utf-8")
+                xml_contents = f.read()
+            finally:
+                f.close()
+
             _, suffix = os.path.split(xml_file)
         else:
-            f = xml_file
+            xml_contents = xml_file.read()
             suffix = ""
 
-        # read and preprocess
-        xml_contents = f.read()
-        f.close()
         xml_contents = re.sub(
             r"(def\w*=\w*[\"\'])(.*)([\"\'])",
             lambda m: m.group(1)


### PR DESCRIPTION
### PR Summary:

This PR ensures XML files are opened in UTF-8 mode while being processed. The background here is ... messy and hard to reproduce. What I'm fairly sure of is that my testing infrastructure writes some temporary files (including Foyer XML files) and something might be loaded under an assumption of ASCII encoding. This causes a crash similar to forcing that behavior:

```python
>>> open('oplsaa.xml', encoding='ascii').read()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/mattthompson/micromamba/envs/new-models/lib/python3.11/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
UnicodeDecodeError: 'ascii' codec can't decode byte 0xce in position 56770: ordinal not in range(128)
```

This is because of the fancy (unicode) $\alpha$ [here](https://github.com/mosdef-hub/foyer/blob/3bb406337493e52d5890dcd6ecee1b1c76ceeb4b/foyer/forcefields/xml/oplsaa.xml#L683):

```python
In [1]: alpha = '\u03b1'

In [2]: alpha
Out[2]: 'α'

In [3]: alpha.encode("utf-8")
Out[3]: b'\xce\xb1'

In [4]: alpha.encode("ascii")
---------------------------------------------------------------------------
UnicodeEncodeError                        Traceback (most recent call last)
Cell In[4], line 1
----> 1 alpha.encode("ascii")

UnicodeEncodeError: 'ascii' codec can't encode character '\u03b1' in position 0: ordinal not in range(128)
```

AFAICT, Python 3 defaults to `open()`ing files in UTF-8 mode, so this change shouldn't impact anything but esoteric cases like I've run into. (Handwaving more, it's a fixture that crashes _only at collection time_ and only when using `pytest-xdist`.) This would be tricky for me to write a unit test for, but I can take a stab at it if desired.

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
