### PR TITLE
Fix documentation build

### DIFF
--- a/codecov.yaml
+++ b/codecov.yaml
@@ -26,6 +26,7 @@ comment:
   require_changes: no
 
 ignore:
-  - "foyer/docs"
+  - "docs"
+  - "foyer/examples"
   - "foyer/tests"
   - "setup.py"

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -24,3 +24,8 @@ comment:
   layout: "header, diff"
   behavior: default
   require_changes: no
+
+ignore:
+  - "foyer/docs"
+  - "foyer/tests"
+  - "setup.py"

--- a/docs/docs-env.yml
+++ b/docs/docs-env.yml
@@ -9,7 +9,7 @@ dependencies:
   - parmed>=3.4.3
   - ele
   - pip:
-    - sphinx<8.0
+    - sphinx
     - sphinx_rtd_theme
     - sphinxcontrib-svg2pdfconverter
     - nbsphinx

--- a/docs/docs-env.yml
+++ b/docs/docs-env.yml
@@ -9,7 +9,7 @@ dependencies:
   - parmed>=3.4.3
   - ele
   - pip:
-    - sphinx
+    - sphinx<8.0
     - sphinx_rtd_theme
     - sphinxcontrib-svg2pdfconverter
     - nbsphinx

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -107,10 +107,10 @@ _python_doc_base = "http://docs.python.org/3.7"
 
 
 intersphinx_mapping = {
-    _python_doc_base: None,
-    "http://docs.scipy.org/doc/numpy": None,
-    "http://docs.scipy.org/doc/scipy/reference": None,
-    "http://scikit-learn.org/stable": None,
+    "python": ("https://docs.python.org/3.11", None),
+    "numpy": ("https://numpy.org/doc/stable", None),
+    "scipy": ("https://docs.scipy.org/doc/scipy/reference", None),
+    "scikit-learn": ("https://scikit-learn.org/stable", None),
 }
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
### PR Summary:

The doc builds were failing with sphinx>=8.0. This PR fixes the source of the error.

### PR Checklist
------------
 - [x] Includes appropriate unit test(s)
 - [x] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [x] Issue(s) raised/addressed?
